### PR TITLE
Add example theory switcher with three new axiom sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@
 
 **vitefolts** is a project aimed at building a TypeScript-based First Order Logic (FOL) engine. The name "vitefolts" is derived from its integration with a Vite frontend. More information about Vite can be found at [vitejs.dev](https://vitejs.dev/).
 
-**Live demo: [rudi-cilibrasi.github.io/vitefolts](https://rudi-cilibrasi.github.io/vitefolts/)** — step the Peano axioms through the clausal-form pipeline (eliminate `→`, eliminate `↔`, cancel `¬¬`, push `¬` inward) and watch each rewrite animate: surviving symbols glide along quadratic Bézier splines with time-parameterized easing, and mirror-image conversions animate as reflections — a De Morgan step literally flips `∧` upside down into `∨` (scaleY 1 → −1), and `∃` flips into `∀`. Deleted symbols fade out; new symbols pop in.
+**Live demo: [rudi-cilibrasi.github.io/vitefolts](https://rudi-cilibrasi.github.io/vitefolts/)** — step an axiom set through the clausal-form pipeline (eliminate `→`, eliminate `↔`, cancel `¬¬`, push `¬` inward) and watch each rewrite animate: surviving symbols glide along quadratic Bézier splines with time-parameterized easing, and mirror-image conversions animate as reflections — a De Morgan step literally flips `∧` upside down into `∨` (scaleY 1 → −1), and `∃` flips into `∀`. Deleted symbols fade out; new symbols pop in.
+
+Four example theories are included, each chosen so a different pipeline step gets a dramatic moment:
+
+- **Peano arithmetic** — the classic axioms, plus a `¬∃x.[NAT(x)]∧[succ(x)=0]` row that double-flips under De Morgan.
+- **Group theory** — closure, associativity, identity, inverses; the "nontrivial" axiom `¬∀x.x=e` flips its quantifier into `∃x.¬(x=e)`.
+- **Socrates & the gods** — syllogisms where `¬∃x.¬MORTAL(x)` cancels a hidden double negation into `∀x.MORTAL(x)`.
+- **Safety interlock** — propositional rules whose biconditionals mint genuine `¬¬` pairs, giving the `¬¬` cancel step real work.
 
 ### Properties of vitefolts
 

--- a/src/anim/plain-printer.ts
+++ b/src/anim/plain-printer.ts
@@ -68,7 +68,14 @@ function printNode(node: SentenceTreeNode, symbol_table: SymbolTable): string {
         case OperationType.FUNCTIONCALL: {
             const entry = symbol_table.find_by_id(bound_vars.get(0)!)!;
             if (entry.is_infix) {
-                return children.map((c) => printNode(c, symbol_table)).join(entry.name);
+                return children.map((c) => {
+                    const s = printNode(c, symbol_table);
+                    // Parenthesize nested infix calls so (x·y)·z ≠ x·(y·z).
+                    const nestedInfix = c.operation === OperationType.FUNCTIONCALL
+                        && !symbol_table.find_definition(c)
+                        && symbol_table.find_by_id(c.bound_vars.get(0)!)!.is_infix;
+                    return nestedInfix ? `(${s})` : s;
+                }).join(entry.name);
             }
             const name = displayName(bound_vars.get(0)!, OperationType.FUNCTIONCALL, symbol_table);
             if (children.size === 0) {

--- a/src/examples.ts
+++ b/src/examples.ts
@@ -1,0 +1,147 @@
+import { List } from 'immutable';
+import { OperationType } from './notation/operation-type.ts';
+import { n2SI, ScopedId } from './notation/scope.ts';
+import { S3, SentenceTreeNode } from './notation/sentence-tree-node.ts';
+import { TruthBag } from './notation/truth-bag.ts';
+import { Axiom, AxiomSet, buildPeanoAxioms } from './axioms.ts';
+
+export interface ExampleDef {
+    name: string;
+    hint: string;
+    build: () => AxiomSet;
+}
+
+// Small combinators so example theories read close to their mathematical form.
+const and = (...cs: SentenceTreeNode[]) => S3(OperationType.AND, List(cs), List([]));
+const not = (c: SentenceTreeNode) => S3(OperationType.NOT, List([c]), List([]));
+const implies = (a: SentenceTreeNode, b: SentenceTreeNode) => S3(OperationType.IMPLIES, List([a, b]), List([]));
+const iff = (a: SentenceTreeNode, b: SentenceTreeNode) => S3(OperationType.IFF, List([a, b]), List([]));
+const forall = (vars: ScopedId[], body: SentenceTreeNode) => S3(OperationType.FORALL, List([body]), List(vars));
+const exists = (vars: ScopedId[], body: SentenceTreeNode) => S3(OperationType.EXISTS, List([body]), List(vars));
+const eq = (a: SentenceTreeNode, b: SentenceTreeNode) => S3(OperationType.EQUALS, List([a, b]), List([]));
+const fn = (id: ScopedId, ...args: SentenceTreeNode[]) => S3(OperationType.FUNCTIONCALL, List(args), List([id]));
+const pred = (id: ScopedId, ...args: SentenceTreeNode[]) => S3(OperationType.PREDICATECALL, List(args), List([id]));
+const varr = (id: ScopedId) => S3(OperationType.VARIABLE_INSTANCE, List(), List([id]));
+
+function buildGroupTheory(): AxiomSet {
+    const G_id = n2SI(0, 0);
+    const e_id = n2SI(0, 1);
+    const dot_id = n2SI(0, 2);
+    const x_id = n2SI(1, 0);
+    const y_id = n2SI(1, 1);
+    const z_id = n2SI(1, 2);
+
+    let truthBag = new TruthBag();
+    truthBag = truthBag.add_predicate(G_id, 'G', 1, false);
+    truthBag = truthBag.add_function(e_id, 'e', 0, false);
+    truthBag = truthBag.add_function(dot_id, '·', 2, true);
+
+    const x = varr(x_id);
+    const y = varr(y_id);
+    const z = varr(z_id);
+    const e = fn(e_id);
+    const G = (t: SentenceTreeNode) => pred(G_id, t);
+    const mul = (a: SentenceTreeNode, b: SentenceTreeNode) => fn(dot_id, a, b);
+
+    const axioms: Axiom[] = [
+        { tree: implies(and(G(x), G(y)), G(mul(x, y))), note: 'closure' },
+        { tree: forall([x_id, y_id, z_id], eq(mul(mul(x, y), z), mul(x, mul(y, z)))), note: 'associativity' },
+        { tree: forall([x_id], and(eq(mul(x, e), x), eq(mul(e, x), x))), note: 'identity' },
+        { tree: forall([x_id], implies(G(x), exists([y_id], and(G(y), eq(mul(x, y), e))))), note: 'inverses' },
+        { tree: not(forall([x_id], eq(x, e))), note: 'nontrivial' },
+    ];
+    for (const a of axioms) {
+        truthBag = truthBag.add_sentence(a.tree, a.note);
+    }
+    return { truthBag, axioms };
+}
+
+function buildSocrates(): AxiomSet {
+    const MAN_id = n2SI(0, 0);
+    const MORTAL_id = n2SI(0, 1);
+    const GOD_id = n2SI(0, 2);
+    const socrates_id = n2SI(0, 3);
+    const x_id = n2SI(1, 0);
+
+    let truthBag = new TruthBag();
+    truthBag = truthBag.add_predicate(MAN_id, 'MAN', 1, false);
+    truthBag = truthBag.add_predicate(MORTAL_id, 'MORTAL', 1, false);
+    truthBag = truthBag.add_predicate(GOD_id, 'GOD', 1, false);
+    truthBag = truthBag.add_function(socrates_id, 'socrates', 0, false);
+
+    const x = varr(x_id);
+    const socrates = fn(socrates_id);
+
+    const axioms: Axiom[] = [
+        { tree: forall([x_id], implies(pred(MAN_id, x), pred(MORTAL_id, x))), note: 'all men are mortal' },
+        { tree: pred(MAN_id, socrates), note: 'socrates is a man' },
+        { tree: forall([x_id], implies(pred(GOD_id, x), not(pred(MORTAL_id, x)))), note: 'gods are immortal' },
+        { tree: not(exists([x_id], and(pred(GOD_id, x), pred(MAN_id, x)))), note: 'no god is a man' },
+        { tree: not(exists([x_id], not(pred(MORTAL_id, x)))), note: 'nothing escapes death' },
+    ];
+    for (const a of axioms) {
+        truthBag = truthBag.add_sentence(a.tree, a.note);
+    }
+    return { truthBag, axioms };
+}
+
+function buildInterlock(): AxiomSet {
+    const RUN_id = n2SI(0, 0);
+    const STOP_id = n2SI(0, 1);
+    const GUARD_id = n2SI(0, 2);
+    const ALARM_id = n2SI(0, 3);
+    const FAULT_id = n2SI(0, 4);
+    const A_OK_id = n2SI(0, 5);
+    const B_OK_id = n2SI(0, 6);
+
+    let truthBag = new TruthBag();
+    truthBag = truthBag.add_predicate(RUN_id, 'RUN', 0, false);
+    truthBag = truthBag.add_predicate(STOP_id, 'STOP', 0, false);
+    truthBag = truthBag.add_predicate(GUARD_id, 'GUARD', 0, false);
+    truthBag = truthBag.add_predicate(ALARM_id, 'ALARM', 0, false);
+    truthBag = truthBag.add_predicate(FAULT_id, 'FAULT', 0, false);
+    truthBag = truthBag.add_predicate(A_OK_id, 'A_OK', 0, false);
+    truthBag = truthBag.add_predicate(B_OK_id, 'B_OK', 0, false);
+
+    const RUN = pred(RUN_id);
+    const STOP = pred(STOP_id);
+    const GUARD = pred(GUARD_id);
+    const ALARM = pred(ALARM_id);
+    const FAULT = pred(FAULT_id);
+    const A_OK = pred(A_OK_id);
+    const B_OK = pred(B_OK_id);
+
+    const axioms: Axiom[] = [
+        { tree: implies(RUN, GUARD), note: 'guard required' },
+        { tree: iff(ALARM, not(GUARD)), note: 'alarm signal' },
+        { tree: iff(FAULT, not(and(A_OK, B_OK))), note: 'sensor fault' },
+        { tree: not(and(RUN, STOP)), note: 'mutual exclusion' },
+    ];
+    for (const a of axioms) {
+        truthBag = truthBag.add_sentence(a.tree, a.note);
+    }
+    return { truthBag, axioms };
+}
+
+export const EXAMPLES: ExampleDef[] = [
+    {
+        name: 'Peano arithmetic',
+        hint: 'The classic axioms of the natural numbers. Watch the De Morgan demo row: ¬∃ flips into ∀ while its ∧ reflects into ∨.',
+        build: buildPeanoAxioms,
+    },
+    {
+        name: 'Group theory',
+        hint: 'Closure, associativity, identity, inverses. The "nontrivial" axiom ¬∀x.x=e flips its quantifier into ∃x.¬(x=e).',
+        build: buildGroupTheory,
+    },
+    {
+        name: 'Socrates & the gods',
+        hint: 'Aristotle with a twist: "no god is a man" double-flips (∃→∀, ∧→∨), and "nothing escapes death" cancels a hidden ¬¬ into ∀x.MORTAL(x).',
+        build: buildSocrates,
+    },
+    {
+        name: 'Safety interlock',
+        hint: 'Propositional machine-safety rules. The biconditionals mint genuine ¬¬ pairs — the only example where the ¬¬ cancel step has real work to do.',
+        build: buildInterlock,
+    },
+];

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import './style.css';
-import { buildPeanoAxioms } from './axioms.ts';
-import { setupApp, PipelineStep } from './ui.ts';
+import { EXAMPLES } from './examples.ts';
+import { setupApp, PipelineStep, ExampleUI } from './ui.ts';
 import {
     clausal_form_iffs_out,
     clausal_form_implications_out,
@@ -8,8 +8,6 @@ import {
     clausal_form_remove_double_negations,
 } from './notation/clause.ts';
 import { print_symbol_table } from './notation/symbol-table-printer.ts';
-
-const { truthBag, axioms } = buildPeanoAxioms();
 
 const steps: PipelineStep[] = [
     {
@@ -34,10 +32,15 @@ const steps: PipelineStep[] = [
     },
 ];
 
-setupApp(
-    document.querySelector<HTMLDivElement>('#app')!,
-    axioms,
-    steps,
-    truthBag.symbol_table,
-    print_symbol_table(truthBag.symbol_table),
-);
+const examples: ExampleUI[] = EXAMPLES.map((def) => {
+    const { truthBag, axioms } = def.build();
+    return {
+        name: def.name,
+        hint: def.hint,
+        axioms,
+        symbolTable: truthBag.symbol_table,
+        symbolTableHtml: print_symbol_table(truthBag.symbol_table),
+    };
+});
+
+setupApp(document.querySelector<HTMLDivElement>('#app')!, examples, steps);

--- a/src/notation/symbol-table.ts
+++ b/src/notation/symbol-table.ts
@@ -65,6 +65,7 @@ export class SymbolTable {
         st.symbols = this.symbols.set(id, sig);
         st.definitionsForward = this.definitionsForward
         st.definitionsReverse = this.definitionsReverse
+        st.annotations = this.annotations
         return st;
     }
     add_predicate(id: ScopedId, name: string, arity: number, is_infix: boolean): SymbolTable {
@@ -84,6 +85,7 @@ export class SymbolTable {
         st.symbols = this.symbols.set(id, sig);
         st.definitionsForward = this.definitionsForward
         st.definitionsReverse = this.definitionsReverse
+        st.annotations = this.annotations
         return st;
     }
     add_function(id: ScopedId, name: string, arity: number, is_infix: boolean): SymbolTable {
@@ -103,6 +105,7 @@ export class SymbolTable {
         st.symbols = this.symbols.set(id, sig);
         st.definitionsForward = this.definitionsForward
         st.definitionsReverse = this.definitionsReverse
+        st.annotations = this.annotations
         return st;
     }
     add_definition(name: string, sentence: SentenceTreeNode): SymbolTable {
@@ -111,6 +114,7 @@ export class SymbolTable {
         st.symbols = this.symbols
         st.definitionsForward = this.definitionsForward.set(name, sentence)
         st.definitionsReverse = this.definitionsReverse.set(sentence, name)
+        st.annotations = this.annotations
         return st;
     }
     get_annotation(sentence: SentenceTreeNode): string | undefined {
@@ -120,8 +124,9 @@ export class SymbolTable {
         const st = new SymbolTable();
         st.names = this.names
         st.symbols = this.symbols
+        st.definitionsForward = this.definitionsForward
+        st.definitionsReverse = this.definitionsReverse
         st.annotations = this.annotations.set(sentence, annotation)
-        console.log("Added annotation for sentence ", annotation)
         return st;
     }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -51,6 +51,51 @@ header h1 {
     font-family: "STIX Two Math", "Cambria Math", "Noto Sans Math", "DejaVu Sans", serif;
 }
 
+.examples {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.4rem;
+}
+
+.ex-tab {
+    font: inherit;
+    font-weight: 600;
+    font-size: 0.92rem;
+    padding: 0.45rem 1rem;
+    border-radius: 10px 10px 0 0;
+    border: 1px solid var(--border);
+    border-bottom: 2px solid transparent;
+    background: var(--panel);
+    color: var(--ink-dim);
+    cursor: pointer;
+    transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.ex-tab:hover:not(:disabled) {
+    color: var(--ink);
+}
+
+.ex-tab.active {
+    color: var(--accent);
+    border-color: var(--accent);
+    background: var(--panel-2);
+}
+
+.ex-tab:disabled {
+    opacity: 0.55;
+    cursor: default;
+}
+
+.hint {
+    color: var(--ink-dim);
+    font-size: 0.9rem;
+    line-height: 1.5;
+    max-width: 78ch;
+    margin: 0 0 1rem;
+    min-height: 2.2em;
+}
+
 .pipeline {
     display: flex;
     flex-wrap: wrap;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -10,6 +10,14 @@ export interface PipelineStep {
     transform: (s: SentenceTreeNode) => SentenceTreeNode;
 }
 
+export interface ExampleUI {
+    name: string;
+    hint: string;
+    axioms: Axiom[];
+    symbolTable: SymbolTable;
+    symbolTableHtml: string;
+}
+
 const BASE_DURATION_MS = 1500;
 
 function sleep(ms: number): Promise<void> {
@@ -18,18 +26,18 @@ function sleep(ms: number): Promise<void> {
 
 export function setupApp(
     root: HTMLElement,
-    axioms: Axiom[],
+    examples: ExampleUI[],
     steps: PipelineStep[],
-    symbolTable: SymbolTable,
-    symbolTableHtml: string,
 ): void {
     root.innerHTML = `
         <header>
             <h1>vitefolts</h1>
-            <p class="tagline">A first-order logic engine — watch the Peano axioms morph into negation normal form.
+            <p class="tagline">A first-order logic engine — watch axiom sets morph into negation normal form.
             Surviving symbols glide along splines; conversions like <span class="hl">∧→∨</span> and
             <span class="hl">∃→∀</span> animate as reflections.</p>
         </header>
+        <section class="examples" id="examples"></section>
+        <p class="hint" id="hint"></p>
         <section class="pipeline" id="pipeline"></section>
         <section class="controls">
             <button id="btn-step" type="button">Step ▸</button>
@@ -47,59 +55,87 @@ export function setupApp(
         <section class="sentences" id="sentences"></section>
         <details class="symbols">
             <summary>Symbol table</summary>
-            ${symbolTableHtml}
+            <div id="symtab"></div>
         </details>
         <footer>
             <a href="https://github.com/rudi-cilibrasi/vitefolts" target="_blank" rel="noopener">source on GitHub</a>
         </footer>
     `;
 
+    const examplesEl = root.querySelector<HTMLElement>('#examples')!;
+    const hintEl = root.querySelector<HTMLElement>('#hint')!;
     const pipelineEl = root.querySelector<HTMLElement>('#pipeline')!;
     const sentencesEl = root.querySelector<HTMLElement>('#sentences')!;
+    const symtabEl = root.querySelector<HTMLElement>('#symtab')!;
     const statusEl = root.querySelector<HTMLElement>('#status')!;
     const stepBtn = root.querySelector<HTMLButtonElement>('#btn-step')!;
     const playBtn = root.querySelector<HTMLButtonElement>('#btn-play')!;
     const resetBtn = root.querySelector<HTMLButtonElement>('#btn-reset')!;
     const speedSel = root.querySelector<HTMLSelectElement>('#speed')!;
 
-    const chips: HTMLElement[] = [];
-    for (const step of steps) {
+    const exampleTabs: HTMLButtonElement[] = examples.map((ex, k) => {
+        const tab = document.createElement('button');
+        tab.type = 'button';
+        tab.className = 'ex-tab';
+        tab.textContent = ex.name;
+        tab.addEventListener('click', () => selectExample(k));
+        examplesEl.appendChild(tab);
+        return tab;
+    });
+
+    const chips: HTMLElement[] = steps.map((step) => {
         const chip = document.createElement('div');
         chip.className = 'chip';
         chip.textContent = step.label;
         chip.title = step.detail;
         pipelineEl.appendChild(chip);
-        chips.push(chip);
-    }
+        return chip;
+    });
     const doneChip = document.createElement('div');
     doneChip.className = 'chip chip-final';
     doneChip.textContent = 'negation normal form';
     pipelineEl.appendChild(doneChip);
 
-    const rowGlyphEls: HTMLElement[] = [];
-    for (const axiom of axioms) {
-        const row = document.createElement('div');
-        row.className = 'sentence-row';
-        const label = document.createElement('div');
-        label.className = 'row-label';
-        label.textContent = axiom.note;
-        const glyphs = document.createElement('div');
-        glyphs.className = 'glyphs';
-        row.appendChild(label);
-        row.appendChild(glyphs);
-        sentencesEl.appendChild(row);
-        rowGlyphEls.push(glyphs);
-    }
-
-    let trees: SentenceTreeNode[] = axioms.map((a) => a.tree);
+    let exampleIndex = -1;
+    let trees: SentenceTreeNode[] = [];
+    let rowGlyphEls: HTMLElement[] = [];
     let stepIndex = 0;
     let busy = false;
+    // Bumped whenever state jumps (reset / example switch) so a play-all loop
+    // sleeping between steps can't wake up and keep stepping the new state.
+    let session = 0;
+
+    function current(): ExampleUI {
+        return examples[exampleIndex];
+    }
+
+    function buildRows(axioms: Axiom[]): void {
+        sentencesEl.textContent = '';
+        rowGlyphEls = [];
+        for (const axiom of axioms) {
+            const row = document.createElement('div');
+            row.className = 'sentence-row';
+            const label = document.createElement('div');
+            label.className = 'row-label';
+            label.textContent = axiom.note;
+            const glyphs = document.createElement('div');
+            glyphs.className = 'glyphs';
+            row.appendChild(label);
+            row.appendChild(glyphs);
+            sentencesEl.appendChild(row);
+            rowGlyphEls.push(glyphs);
+        }
+    }
 
     function renderAll(): void {
-        trees.forEach((tree, k) => renderStatic(rowGlyphEls[k], printPlainSentence(tree, symbolTable)));
+        trees.forEach((tree, k) => renderStatic(rowGlyphEls[k], printPlainSentence(tree, current().symbolTable)));
     }
 
     function updateChrome(): void {
+        exampleTabs.forEach((tab, k) => {
+            tab.classList.toggle('active', k === exampleIndex);
+            tab.disabled = busy;
+        });
         chips.forEach((chip, k) => {
             chip.classList.toggle('done', k < stepIndex);
             chip.classList.toggle('current', k === stepIndex);
@@ -115,6 +151,21 @@ export function setupApp(
         }
     }
 
+    function selectExample(k: number): void {
+        if (busy || k === exampleIndex) return;
+        session++;
+        exampleIndex = k;
+        const ex = current();
+        trees = ex.axioms.map((a) => a.tree);
+        stepIndex = 0;
+        statusEl.textContent = '';
+        hintEl.textContent = ex.hint;
+        symtabEl.innerHTML = ex.symbolTableHtml;
+        buildRows(ex.axioms);
+        renderAll();
+        updateChrome();
+    }
+
     function durationMult(): number {
         return parseFloat(speedSel.value);
     }
@@ -125,6 +176,7 @@ export function setupApp(
         const step = steps[stepIndex];
         statusEl.textContent = step.detail;
         updateChrome();
+        const symbolTable = current().symbolTable;
         const newTrees = trees.map(step.transform);
         const newTexts = newTrees.map((t) => printPlainSentence(t, symbolTable));
         const oldTexts = trees.map((t) => printPlainSentence(t, symbolTable));
@@ -143,7 +195,8 @@ export function setupApp(
     }
 
     async function playAll(): Promise<void> {
-        while (stepIndex < steps.length && !busy) {
+        const mySession = session;
+        while (stepIndex < steps.length && !busy && session === mySession) {
             await doStep();
             await sleep(420 * durationMult());
         }
@@ -151,7 +204,8 @@ export function setupApp(
 
     function reset(): void {
         if (busy) return;
-        trees = axioms.map((a) => a.tree);
+        session++;
+        trees = current().axioms.map((a) => a.tree);
         stepIndex = 0;
         statusEl.textContent = '';
         renderAll();
@@ -162,6 +216,5 @@ export function setupApp(
     playBtn.addEventListener('click', () => { void playAll(); });
     resetBtn.addEventListener('click', reset);
 
-    renderAll();
-    updateChrome();
+    selectExample(0);
 }


### PR DESCRIPTION
Adds a tab switcher with three new example theories alongside Peano arithmetic, each chosen so a different pipeline step gets a dramatic animated moment:

- **Group theory** — the "nontrivial" axiom `¬∀x.x=e` flips its quantifier into `∃x.¬(x=e)`
- **Socrates & the gods** — `¬∃x.[GOD(x)]∧[MAN(x)]` double-flips (∃→∀, ∧→∨) and `¬∃x.¬MORTAL(x)` cancels a hidden ¬¬ into `∀x.MORTAL(x)`
- **Safety interlock** — propositional biconditionals like `ALARM ↔ ¬GUARD` mint genuine `¬¬` pairs, so the ¬¬ cancel step finally has real work (it was a no-op on Peano)

Also:
- Fix a race where **Play all** kept stepping after Reset/example-switch during its inter-step sleep
- Parenthesize nested infix calls so `(x·y)·z` prints unambiguously
- Fix `SymbolTable` copies silently dropping annotations/definitions

Verified headlessly: all four examples reach correct negation normal form with zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)