### PR TITLE
Animated linear-resolution prover with paramodulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 **vitefolts** is a project aimed at building a TypeScript-based First Order Logic (FOL) engine. The name "vitefolts" is derived from its integration with a Vite frontend. More information about Vite can be found at [vitejs.dev](https://vitejs.dev/).
 
-**Live demo: [rudi-cilibrasi.github.io/vitefolts](https://rudi-cilibrasi.github.io/vitefolts/)** — step an axiom set through the clausal-form pipeline (eliminate `→`, eliminate `↔`, cancel `¬¬`, push `¬` inward) and watch each rewrite animate: surviving symbols glide along quadratic Bézier splines with time-parameterized easing, and mirror-image conversions animate as reflections — a De Morgan step literally flips `∧` upside down into `∨` (scaleY 1 → −1), and `∃` flips into `∀`. Deleted symbols fade out; new symbols pop in.
+**Live demo: [rudi-cilibrasi.github.io/vitefolts](https://rudi-cilibrasi.github.io/vitefolts/)** — step an axiom set through the full clausal-form pipeline (eliminate `→`, eliminate `↔`, cancel `¬¬`, push `¬` inward, Skolemize `∃`, drop `∀`, distribute `∨` over `∧`) and watch each rewrite animate: surviving symbols glide along quadratic Bézier splines with time-parameterized easing, and mirror-image conversions animate as reflections — a De Morgan step literally flips `∧` upside down into `∨` (scaleY 1 → −1), and `∃` flips into `∀`. Deleted symbols fade out; new symbols pop in.
+
+Then **prove a conjecture**: pick a conjecture φ and the engine refutes axioms ∧ ¬φ by **linear resolution with paramodulation** — unification with occurs check, binary resolution, factoring, and equality rewriting, searched by iterative deepening so the shortest proof is found. Every derivation animates with the same glyph engine: the parent clauses fuse, the resolved complementary literals annihilate, and unified variables visibly morph into their substituted terms, ending at the empty clause `□`. Conjectures that don't follow (try `GOD(socrates)`) report an honest search failure.
 
 Four example theories are included, each chosen so a different pipeline step gets a dramatic moment:
 

--- a/src/anim/plain-printer.ts
+++ b/src/anim/plain-printer.ts
@@ -104,3 +104,7 @@ function printNode(node: SentenceTreeNode, symbol_table: SymbolTable): string {
 export function printPlainSentence(node: SentenceTreeNode, symbol_table: SymbolTable): string {
     return printNode(node, symbol_table);
 }
+
+export function variableDisplayName(symbol: ScopedId, symbol_table: SymbolTable): string {
+    return displayName(symbol, OperationType.VARIABLE_INSTANCE, symbol_table);
+}

--- a/src/axioms.ts
+++ b/src/axioms.ts
@@ -1,4 +1,5 @@
 import { List } from 'immutable';
+import { exists, fn, pred, varr } from "./notation/builders.ts";
 import { OperationType } from "./notation/operation-type.ts";
 import { n2SI, ScopedId } from "./notation/scope.ts";
 import { S3, SentenceTreeNode } from './notation/sentence-tree-node.ts';
@@ -9,9 +10,15 @@ export interface Axiom {
     note: string;
 }
 
+export interface Conjecture {
+    tree: SentenceTreeNode;
+    remark?: string;
+}
+
 export interface AxiomSet {
     truthBag: TruthBag;
     axioms: Axiom[];
+    conjectures: Conjecture[];
 }
 
 const nat_id = n2SI(0, 0);
@@ -113,5 +120,11 @@ export function buildPeanoAxioms(): AxiomSet {
     const forall_x__x_plus_zero_eq_x = S3(OperationType.FORALL, List([x_plus_zero_eq_x]), List([x_id]));
     addAxiom(forall_x__x_plus_zero_eq_x, "additive identity");
 
-    return { truthBag, axioms };
+    const conjectures: Conjecture[] = [
+        { tree: exists([x_id], pred(nat_id, fn(succ, varr(x_id)))) },
+        { tree: pred(nat_id, fn(PLUS, zero, zero)), remark: 'needs paramodulation' },
+        { tree: pred(nat_id, succ_zero), remark: '1 is defined as succ(0)' },
+    ];
+
+    return { truthBag, axioms, conjectures };
 }

--- a/src/examples.ts
+++ b/src/examples.ts
@@ -1,27 +1,14 @@
-import { List } from 'immutable';
-import { OperationType } from './notation/operation-type.ts';
-import { n2SI, ScopedId } from './notation/scope.ts';
-import { S3, SentenceTreeNode } from './notation/sentence-tree-node.ts';
+import { and, eq, exists, fn, forall, iff, implies, not, or, pred, varr } from './notation/builders.ts';
+import { n2SI } from './notation/scope.ts';
+import { SentenceTreeNode } from './notation/sentence-tree-node.ts';
 import { TruthBag } from './notation/truth-bag.ts';
-import { Axiom, AxiomSet, buildPeanoAxioms } from './axioms.ts';
+import { Axiom, AxiomSet, Conjecture, buildPeanoAxioms } from './axioms.ts';
 
 export interface ExampleDef {
     name: string;
     hint: string;
     build: () => AxiomSet;
 }
-
-// Small combinators so example theories read close to their mathematical form.
-const and = (...cs: SentenceTreeNode[]) => S3(OperationType.AND, List(cs), List([]));
-const not = (c: SentenceTreeNode) => S3(OperationType.NOT, List([c]), List([]));
-const implies = (a: SentenceTreeNode, b: SentenceTreeNode) => S3(OperationType.IMPLIES, List([a, b]), List([]));
-const iff = (a: SentenceTreeNode, b: SentenceTreeNode) => S3(OperationType.IFF, List([a, b]), List([]));
-const forall = (vars: ScopedId[], body: SentenceTreeNode) => S3(OperationType.FORALL, List([body]), List(vars));
-const exists = (vars: ScopedId[], body: SentenceTreeNode) => S3(OperationType.EXISTS, List([body]), List(vars));
-const eq = (a: SentenceTreeNode, b: SentenceTreeNode) => S3(OperationType.EQUALS, List([a, b]), List([]));
-const fn = (id: ScopedId, ...args: SentenceTreeNode[]) => S3(OperationType.FUNCTIONCALL, List(args), List([id]));
-const pred = (id: ScopedId, ...args: SentenceTreeNode[]) => S3(OperationType.PREDICATECALL, List(args), List([id]));
-const varr = (id: ScopedId) => S3(OperationType.VARIABLE_INSTANCE, List(), List([id]));
 
 function buildGroupTheory(): AxiomSet {
     const G_id = n2SI(0, 0);
@@ -50,10 +37,14 @@ function buildGroupTheory(): AxiomSet {
         { tree: forall([x_id], implies(G(x), exists([y_id], and(G(y), eq(mul(x, y), e))))), note: 'inverses' },
         { tree: not(forall([x_id], eq(x, e))), note: 'nontrivial' },
     ];
+    const conjectures: Conjecture[] = [
+        { tree: eq(mul(e, mul(e, e)), e), remark: 'needs paramodulation' },
+        { tree: exists([y_id], eq(mul(e, y), e)) },
+    ];
     for (const a of axioms) {
         truthBag = truthBag.add_sentence(a.tree, a.note);
     }
-    return { truthBag, axioms };
+    return { truthBag, axioms, conjectures };
 }
 
 function buildSocrates(): AxiomSet {
@@ -79,10 +70,15 @@ function buildSocrates(): AxiomSet {
         { tree: not(exists([x_id], and(pred(GOD_id, x), pred(MAN_id, x)))), note: 'no god is a man' },
         { tree: not(exists([x_id], not(pred(MORTAL_id, x)))), note: 'nothing escapes death' },
     ];
+    const conjectures: Conjecture[] = [
+        { tree: pred(MORTAL_id, socrates) },
+        { tree: not(pred(GOD_id, socrates)) },
+        { tree: pred(GOD_id, socrates), remark: 'not entailed — watch the search fail' },
+    ];
     for (const a of axioms) {
         truthBag = truthBag.add_sentence(a.tree, a.note);
     }
-    return { truthBag, axioms };
+    return { truthBag, axioms, conjectures };
 }
 
 function buildInterlock(): AxiomSet {
@@ -117,10 +113,14 @@ function buildInterlock(): AxiomSet {
         { tree: iff(FAULT, not(and(A_OK, B_OK))), note: 'sensor fault' },
         { tree: not(and(RUN, STOP)), note: 'mutual exclusion' },
     ];
+    const conjectures: Conjecture[] = [
+        { tree: implies(RUN, not(ALARM)) },
+        { tree: or(A_OK, FAULT) },
+    ];
     for (const a of axioms) {
         truthBag = truthBag.add_sentence(a.tree, a.note);
     }
-    return { truthBag, axioms };
+    return { truthBag, axioms, conjectures };
 }
 
 export const EXAMPLES: ExampleDef[] = [

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,39 +7,54 @@ import {
     clausal_form_negations_in,
     clausal_form_remove_double_negations,
 } from './notation/clause.ts';
-import { print_symbol_table } from './notation/symbol-table-printer.ts';
+import { distribute_or_over_and, drop_foralls, skolemize } from './notation/cnf.ts';
 
 const steps: PipelineStep[] = [
     {
         label: '→ out',
         detail: 'Eliminate implications: A → B rewrites to (¬A)∨(B).',
-        transform: clausal_form_implications_out,
+        transform: (s) => clausal_form_implications_out(s),
     },
     {
         label: '↔ out',
         detail: 'Eliminate biconditionals: A ↔ B rewrites to [(¬A)∨(B)]∧[(A)∨(¬B)].',
-        transform: clausal_form_iffs_out,
+        transform: (s) => clausal_form_iffs_out(s),
     },
     {
         label: '¬¬ cancel',
         detail: 'Remove double negations: ¬¬A rewrites to A.',
-        transform: clausal_form_remove_double_negations,
+        transform: (s) => clausal_form_remove_double_negations(s),
     },
     {
         label: '¬ inward',
         detail: 'Push negations inward (De Morgan): ¬(A∧B) reflects the ∧ into ∨, ¬∃ flips into ∀¬.',
-        transform: clausal_form_negations_in,
+        transform: (s) => clausal_form_negations_in(s),
+    },
+    {
+        label: '∃ skolem',
+        detail: 'Skolemize: each ∃-variable becomes a Skolem function σₖ of the ∀-variables in scope.',
+        transform: (s, ctx) => skolemize(s, ctx),
+    },
+    {
+        label: '∀ drop',
+        detail: 'Drop universal quantifiers — every remaining variable is implicitly universal.',
+        transform: (s) => drop_foralls(s),
+    },
+    {
+        label: '∨ over ∧',
+        detail: 'Distribute ∨ over ∧ to reach conjunctive normal form.',
+        transform: (s) => distribute_or_over_and(s),
     },
 ];
 
 const examples: ExampleUI[] = EXAMPLES.map((def) => {
-    const { truthBag, axioms } = def.build();
+    const { truthBag, axioms, conjectures } = def.build();
     return {
         name: def.name,
         hint: def.hint,
         axioms,
+        conjectures,
         symbolTable: truthBag.symbol_table,
-        symbolTableHtml: print_symbol_table(truthBag.symbol_table),
     };
 });
 

--- a/src/notation/builders.ts
+++ b/src/notation/builders.ts
@@ -1,0 +1,19 @@
+import { List } from 'immutable';
+import { OperationType } from './operation-type';
+import { ScopedId } from './scope';
+import { S3, SentenceTreeNode } from './sentence-tree-node';
+
+// Small combinators so axiom sets and conjectures read close to their
+// mathematical form.
+
+export const and = (...cs: SentenceTreeNode[]) => S3(OperationType.AND, List(cs), List([]));
+export const or = (...cs: SentenceTreeNode[]) => S3(OperationType.OR, List(cs), List([]));
+export const not = (c: SentenceTreeNode) => S3(OperationType.NOT, List([c]), List([]));
+export const implies = (a: SentenceTreeNode, b: SentenceTreeNode) => S3(OperationType.IMPLIES, List([a, b]), List([]));
+export const iff = (a: SentenceTreeNode, b: SentenceTreeNode) => S3(OperationType.IFF, List([a, b]), List([]));
+export const forall = (vars: ScopedId[], body: SentenceTreeNode) => S3(OperationType.FORALL, List([body]), List(vars));
+export const exists = (vars: ScopedId[], body: SentenceTreeNode) => S3(OperationType.EXISTS, List([body]), List(vars));
+export const eq = (a: SentenceTreeNode, b: SentenceTreeNode) => S3(OperationType.EQUALS, List([a, b]), List([]));
+export const fn = (id: ScopedId, ...args: SentenceTreeNode[]) => S3(OperationType.FUNCTIONCALL, List(args), List([id]));
+export const pred = (id: ScopedId, ...args: SentenceTreeNode[]) => S3(OperationType.PREDICATECALL, List(args), List([id]));
+export const varr = (id: ScopedId) => S3(OperationType.VARIABLE_INSTANCE, List(), List([id]));

--- a/src/notation/cnf.ts
+++ b/src/notation/cnf.ts
@@ -1,0 +1,171 @@
+import { List } from 'immutable';
+import { OperationType } from './operation-type';
+import { ScopedId } from './scope';
+import { S3, S3F, SentenceTreeNode } from './sentence-tree-node';
+
+// Completion of the clausal-form pipeline: skolemization, universal
+// quantifier dropping, ∨/∧ distribution, and clause extraction. These run
+// after the NNF steps in clause.ts.
+
+// Pipeline steps that mint new symbols (Skolem functions) report them
+// through this context so the UI can register them in the symbol table.
+export interface StepContext {
+    freshSkolem(arity: number): ScopedId;
+}
+
+export function freeVars(tree: SentenceTreeNode): ScopedId[] {
+    const found: ScopedId[] = [];
+    const seen = new Set<ScopedId>();
+    const walk = (node: SentenceTreeNode, bound: Set<ScopedId>) => {
+        if (node.operation === OperationType.VARIABLE_INSTANCE) {
+            const id = node.bound_vars.get(0)!;
+            if (!bound.has(id) && !seen.has(id)) {
+                seen.add(id);
+                found.push(id);
+            }
+            return;
+        }
+        let inner = bound;
+        if (node.operation === OperationType.FORALL || node.operation === OperationType.EXISTS) {
+            inner = new Set(bound);
+            for (const v of node.bound_vars) {
+                inner.add(v);
+            }
+        }
+        for (const child of node.children) {
+            walk(child, inner);
+        }
+    };
+    walk(tree, new Set());
+    return found;
+}
+
+// Replace each ∃-bound variable with a Skolem function applied to the
+// universally quantified variables in scope at that point. Assumes NNF (no
+// ∃ under an unprocessed ¬). Free variables of the sentence are implicitly
+// universal, so they participate as Skolem arguments too.
+export function skolemize(tree: SentenceTreeNode, ctx: StepContext): SentenceTreeNode {
+    const walk = (node: SentenceTreeNode, univ: ScopedId[], repl: Map<ScopedId, SentenceTreeNode>): SentenceTreeNode => {
+        switch (node.operation) {
+            case OperationType.VARIABLE_INSTANCE: {
+                const id = node.bound_vars.get(0)!;
+                const r = repl.get(id);
+                return r === undefined ? node : r;
+            }
+            case OperationType.FORALL: {
+                const inner = univ.concat(node.bound_vars.toArray());
+                const children = node.children.map((c) => walk(c, inner, repl));
+                return S3F({ operation: node.operation, children, bound_vars: node.bound_vars });
+            }
+            case OperationType.EXISTS: {
+                const nextRepl = new Map(repl);
+                for (const v of node.bound_vars) {
+                    const skId = ctx.freshSkolem(univ.length);
+                    const args = List(univ.map((u) => S3(OperationType.VARIABLE_INSTANCE, List(), List([u]))));
+                    nextRepl.set(v, S3(OperationType.FUNCTIONCALL, args, List([skId])));
+                }
+                return walk(node.children.get(0)!, univ, nextRepl);
+            }
+            default: {
+                if (node.children.size === 0) return node;
+                const children = node.children.map((c) => walk(c, univ, repl));
+                return S3F({ operation: node.operation, children, bound_vars: node.bound_vars });
+            }
+        }
+    };
+    return walk(tree, freeVars(tree), new Map());
+}
+
+export function drop_foralls(tree: SentenceTreeNode): SentenceTreeNode {
+    if (tree.operation === OperationType.FORALL) {
+        return drop_foralls(tree.children.get(0)!);
+    }
+    if (tree.children.size === 0) return tree;
+    const children = tree.children.map(drop_foralls);
+    return S3F({ operation: tree.operation, children, bound_vars: tree.bound_vars });
+}
+
+function leavesOf(op: OperationType, node: SentenceTreeNode): SentenceTreeNode[] {
+    if (node.operation === op) {
+        const out: SentenceTreeNode[] = [];
+        for (const c of node.children) {
+            out.push(...leavesOf(op, c));
+        }
+        return out;
+    }
+    return [node];
+}
+
+// Distribute ∨ over ∧ (and flatten nested ∧/∨) to reach CNF. Assumes a
+// quantifier-free NNF input.
+export function distribute_or_over_and(tree: SentenceTreeNode): SentenceTreeNode {
+    if (tree.operation === OperationType.AND) {
+        const parts = tree.children.map(distribute_or_over_and);
+        const leaves: SentenceTreeNode[] = [];
+        for (const p of parts) {
+            leaves.push(...leavesOf(OperationType.AND, p));
+        }
+        return leaves.length === 1 ? leaves[0] : S3(OperationType.AND, List(leaves), List([]));
+    }
+    if (tree.operation === OperationType.OR) {
+        const parts: SentenceTreeNode[] = [];
+        for (const c of tree.children) {
+            parts.push(...leavesOf(OperationType.OR, distribute_or_over_and(c)));
+        }
+        const andIndex = parts.findIndex((p) => p.operation === OperationType.AND);
+        if (andIndex === -1) {
+            return parts.length === 1 ? parts[0] : S3(OperationType.OR, List(parts), List([]));
+        }
+        const andPart = parts[andIndex];
+        const rest = parts.filter((_, i) => i !== andIndex);
+        const conjuncts = andPart.children.map((conj) =>
+            distribute_or_over_and(S3(OperationType.OR, List([conj, ...rest]), List([]))));
+        return distribute_or_over_and(S3(OperationType.AND, conjuncts, List([])));
+    }
+    return tree;
+}
+
+export interface Literal {
+    positive: boolean;
+    atom: SentenceTreeNode;
+}
+
+export interface Clause {
+    literals: Literal[];
+}
+
+function parseLiteral(node: SentenceTreeNode): Literal {
+    if (node.operation === OperationType.NOT) {
+        const atom = node.children.get(0)!;
+        if (atom.operation !== OperationType.PREDICATECALL && atom.operation !== OperationType.EQUALS) {
+            throw new Error(`Expected atom under ¬, got ${OperationType[atom.operation]}`);
+        }
+        return { positive: false, atom };
+    }
+    if (node.operation !== OperationType.PREDICATECALL && node.operation !== OperationType.EQUALS) {
+        throw new Error(`Expected literal, got ${OperationType[node.operation]}`);
+    }
+    return { positive: true, atom: node };
+}
+
+// Split a CNF sentence into clauses (each a set of literals).
+export function extractClauses(tree: SentenceTreeNode): Clause[] {
+    return leavesOf(OperationType.AND, tree).map((disjunct) => {
+        const literals = leavesOf(OperationType.OR, disjunct).map(parseLiteral);
+        return { literals: dedupeLiterals(literals) };
+    });
+}
+
+export function dedupeLiterals(literals: Literal[]): Literal[] {
+    const out: Literal[] = [];
+    for (const l of literals) {
+        if (!out.some((m) => m.positive === l.positive && m.atom.equals(l.atom))) {
+            out.push(l);
+        }
+    }
+    return out;
+}
+
+export function clauseHasEquality(clause: Clause): boolean {
+    return clause.literals.some((l) => l.atom.operation === OperationType.EQUALS);
+}

--- a/src/notation/resolution.ts
+++ b/src/notation/resolution.ts
@@ -1,0 +1,283 @@
+import { List } from 'immutable';
+import { Clause, Literal, dedupeLiterals } from './cnf';
+import { OperationType } from './operation-type';
+import { ScopedId } from './scope';
+import { S3, S3F, SentenceTreeNode } from './sentence-tree-node';
+import { Subst, applySubst, isVar, termSize, unifyAtoms, unifyTerms, varId } from './unify';
+
+// Linear resolution with paramodulation. The prover refutes
+// axioms ∧ ¬conjecture by deriving the empty clause □: each step combines
+// the current center clause with an input clause or an ancestor, via
+//  * binary resolution (complementary literals unify),
+//  * paramodulation (a positive equality s=t in the side clause rewrites a
+//    subterm of the center clause), or
+//  * factoring (two center literals of the same sign unify).
+// Search is iterative-deepening DFS over proof length, smallest resolvents
+// first, so the shortest proof is found.
+
+export interface ProverEnv {
+    // Return a fresh variable id whose display name shadows `base` (e.g. x → x′).
+    freshVar(base: ScopedId): ScopedId;
+}
+
+export type SideRef =
+    | { kind: 'input'; index: number }
+    | { kind: 'derived'; index: number };
+
+export interface ProofStep {
+    kind: 'resolve' | 'paramodulate' | 'factor';
+    sideRef: SideRef | null;
+    sideRenamed: Clause | null;
+    substPairs: Array<[ScopedId, SentenceTreeNode]>;
+    resolvent: Clause;
+}
+
+export interface Proof {
+    startIndex: number;   // index into the input clause list where the chain begins
+    steps: ProofStep[];
+}
+
+function clauseVars(clause: Clause): ScopedId[] {
+    const out: ScopedId[] = [];
+    const seen = new Set<ScopedId>();
+    const walk = (t: SentenceTreeNode) => {
+        if (isVar(t)) {
+            const id = varId(t);
+            if (!seen.has(id)) {
+                seen.add(id);
+                out.push(id);
+            }
+            return;
+        }
+        for (const c of t.children) walk(c);
+    };
+    for (const l of clause.literals) walk(l.atom);
+    return out;
+}
+
+function renameClause(clause: Clause, env: ProverEnv): Clause {
+    const vars = clauseVars(clause);
+    if (vars.length === 0) return clause;
+    const subst: Subst = new Map();
+    for (const v of vars) {
+        subst.set(v, S3(OperationType.VARIABLE_INSTANCE, List(), List([env.freshVar(v)])));
+    }
+    return { literals: clause.literals.map((l) => ({ positive: l.positive, atom: applySubst(l.atom, subst) })) };
+}
+
+function substClause(clause: Clause, subst: Subst): Clause {
+    return { literals: dedupeLiterals(clause.literals.map((l) => ({ positive: l.positive, atom: applySubst(l.atom, subst) }))) };
+}
+
+function isTautology(clause: Clause): boolean {
+    return clause.literals.some((l) =>
+        l.positive && clause.literals.some((m) => !m.positive && m.atom.equals(l.atom)));
+}
+
+function clauseSize(clause: Clause): number {
+    let size = 0;
+    for (const l of clause.literals) size += termSize(l.atom);
+    return size;
+}
+
+function clauseKey(clause: Clause): string {
+    return clause.literals
+        .map((l) => `${l.positive ? '+' : '-'}${l.atom.hashCode()}`)
+        .sort()
+        .join('|');
+}
+
+function swapEquals(atom: SentenceTreeNode): SentenceTreeNode | null {
+    if (atom.operation !== OperationType.EQUALS) return null;
+    return S3F({
+        operation: OperationType.EQUALS,
+        children: List([atom.children.get(1)!, atom.children.get(0)!]),
+        bound_vars: atom.bound_vars,
+    });
+}
+
+function substPairsOf(subst: Subst): Array<[ScopedId, SentenceTreeNode]> {
+    const pairs: Array<[ScopedId, SentenceTreeNode]> = [];
+    for (const [id] of subst) {
+        pairs.push([id, applySubst(S3(OperationType.VARIABLE_INSTANCE, List(), List([id])), subst)]);
+    }
+    return pairs;
+}
+
+interface TermPosition {
+    path: number[];
+    term: SentenceTreeNode;
+}
+
+// All non-variable term positions inside an atom's arguments.
+function termPositions(atom: SentenceTreeNode): TermPosition[] {
+    const out: TermPosition[] = [];
+    const walk = (t: SentenceTreeNode, path: number[]) => {
+        if (isVar(t)) return;
+        out.push({ path, term: t });
+        t.children.forEach((c, i) => walk(c, [...path, i]));
+    };
+    atom.children.forEach((c, i) => walk(c, [i]));
+    return out;
+}
+
+function replaceAt(node: SentenceTreeNode, path: number[], replacement: SentenceTreeNode): SentenceTreeNode {
+    if (path.length === 0) return replacement;
+    const [head, ...rest] = path;
+    const children = node.children.map((c, i) => (i === head ? replaceAt(c, rest, replacement) : c));
+    return S3F({ operation: node.operation, children, bound_vars: node.bound_vars });
+}
+
+interface Candidate {
+    step: ProofStep;
+}
+
+const MAX_LITERALS = 6;
+const MAX_CLAUSE_SIZE = 60;
+
+function candidatesWith(center: Clause, side: Clause, sideRef: SideRef, env: ProverEnv): Candidate[] {
+    const out: Candidate[] = [];
+    const renamed = renameClause(side, env);
+    const push = (kind: ProofStep['kind'], subst: Subst, resolvent: Clause, withSide: boolean) => {
+        if (resolvent.literals.length > MAX_LITERALS) return;
+        if (clauseSize(resolvent) > MAX_CLAUSE_SIZE) return;
+        if (isTautology(resolvent)) return;
+        out.push({
+            step: {
+                kind,
+                sideRef: withSide ? sideRef : null,
+                sideRenamed: withSide ? renamed : null,
+                substPairs: substPairsOf(subst),
+                resolvent,
+            },
+        });
+    };
+
+    // Binary resolution: center literal against complementary side literal.
+    center.literals.forEach((cl, ci) => {
+        renamed.literals.forEach((sl, si) => {
+            if (cl.positive === sl.positive) return;
+            const sideAtoms = [sl.atom];
+            const swapped = swapEquals(sl.atom);
+            if (swapped !== null) sideAtoms.push(swapped);
+            for (const sideAtom of sideAtoms) {
+                const subst: Subst = new Map();
+                if (!unifyAtoms(cl.atom, sideAtom, subst)) continue;
+                const rest: Literal[] = [
+                    ...center.literals.filter((_, i) => i !== ci),
+                    ...renamed.literals.filter((_, i) => i !== si),
+                ];
+                push('resolve', subst, substClause({ literals: rest }, subst), true);
+                break;
+            }
+        });
+    });
+
+    // Paramodulation: positive equality in the side clause rewrites a
+    // non-variable subterm of a center literal.
+    renamed.literals.forEach((sl, si) => {
+        if (!sl.positive || sl.atom.operation !== OperationType.EQUALS) return;
+        const s = sl.atom.children.get(0)!;
+        const t = sl.atom.children.get(1)!;
+        const orientations: Array<[SentenceTreeNode, SentenceTreeNode]> = [[s, t], [t, s]];
+        for (const [from, to] of orientations) {
+            if (isVar(from)) continue;
+            center.literals.forEach((cl, ci) => {
+                for (const pos of termPositions(cl.atom)) {
+                    const subst: Subst = new Map();
+                    if (!unifyTerms(pos.term, from, subst)) continue;
+                    const newAtom = replaceAt(cl.atom, pos.path, to);
+                    const rest: Literal[] = [
+                        ...center.literals.filter((_, i) => i !== ci),
+                        { positive: cl.positive, atom: newAtom },
+                        ...renamed.literals.filter((_, i) => i !== si),
+                    ];
+                    push('paramodulate', subst, substClause({ literals: rest }, subst), true);
+                }
+            });
+        }
+    });
+
+    return out;
+}
+
+function factorCandidates(center: Clause): Candidate[] {
+    const out: Candidate[] = [];
+    center.literals.forEach((a, i) => {
+        center.literals.forEach((b, j) => {
+            if (j <= i || a.positive !== b.positive) return;
+            const subst: Subst = new Map();
+            if (!unifyAtoms(a.atom, b.atom, subst)) return;
+            const rest = center.literals.filter((_, k) => k !== j);
+            const resolvent = substClause({ literals: rest }, subst);
+            if (isTautology(resolvent)) return;
+            out.push({
+                step: {
+                    kind: 'factor',
+                    sideRef: null,
+                    sideRenamed: null,
+                    substPairs: substPairsOf(subst),
+                    resolvent,
+                },
+            });
+        });
+    });
+    return out;
+}
+
+export interface ProveOptions {
+    maxDepth?: number;
+    maxAttempts?: number;
+}
+
+export function prove(inputs: Clause[], sosIndices: number[], env: ProverEnv, options?: ProveOptions): Proof | null {
+    const maxDepth = options?.maxDepth ?? 8;
+    const budget = { attempts: 0, max: options?.maxAttempts ?? 20000 };
+
+    const dfs = (
+        center: Clause,
+        derived: Clause[],
+        seen: Set<string>,
+        remaining: number,
+    ): ProofStep[] | null => {
+        if (center.literals.length === 0) return [];
+        if (remaining === 0) return null;
+        if (budget.attempts > budget.max) return null;
+
+        const candidates: Candidate[] = [];
+        inputs.forEach((clause, index) => {
+            candidates.push(...candidatesWith(center, clause, { kind: 'input', index }, env));
+        });
+        derived.forEach((clause, index) => {
+            candidates.push(...candidatesWith(center, clause, { kind: 'derived', index }, env));
+        });
+        candidates.push(...factorCandidates(center));
+        candidates.sort((a, b) => a.step.resolvent.literals.length - b.step.resolvent.literals.length
+            || clauseSize(a.step.resolvent) - clauseSize(b.step.resolvent));
+
+        for (const cand of candidates) {
+            budget.attempts++;
+            if (budget.attempts > budget.max) return null;
+            const key = clauseKey(cand.step.resolvent);
+            if (seen.has(key)) continue;
+            seen.add(key);
+            const rest = dfs(cand.step.resolvent, [...derived, center], seen, remaining - 1);
+            seen.delete(key);
+            if (rest !== null) {
+                return [cand.step, ...rest];
+            }
+        }
+        return null;
+    };
+
+    for (let depth = 1; depth <= maxDepth; depth++) {
+        for (const start of sosIndices) {
+            const center = inputs[start];
+            const steps = dfs(center, [], new Set([clauseKey(center)]), depth);
+            if (steps !== null) {
+                return { startIndex: start, steps };
+            }
+        }
+    }
+    return null;
+}

--- a/src/notation/unify.ts
+++ b/src/notation/unify.ts
@@ -1,0 +1,92 @@
+import { OperationType } from './operation-type';
+import { ScopedId } from './scope';
+import { S3F, SentenceTreeNode } from './sentence-tree-node';
+
+// First-order term unification with occurs check, over the term fragment of
+// SentenceTreeNode (VARIABLE_INSTANCE and FUNCTIONCALL). Substitutions are
+// triangular: bindings may map a variable to a term containing further bound
+// variables; deref/applySubst chase the chain.
+
+export type Subst = Map<ScopedId, SentenceTreeNode>;
+
+export function isVar(t: SentenceTreeNode): boolean {
+    return t.operation === OperationType.VARIABLE_INSTANCE;
+}
+
+export function varId(t: SentenceTreeNode): ScopedId {
+    return t.bound_vars.get(0)!;
+}
+
+export function deref(t: SentenceTreeNode, subst: Subst): SentenceTreeNode {
+    while (isVar(t)) {
+        const bound = subst.get(varId(t));
+        if (bound === undefined) break;
+        t = bound;
+    }
+    return t;
+}
+
+function occurs(id: ScopedId, t: SentenceTreeNode, subst: Subst): boolean {
+    t = deref(t, subst);
+    if (isVar(t)) {
+        return varId(t) === id;
+    }
+    return t.children.some((c) => occurs(id, c, subst));
+}
+
+export function unifyTerms(a: SentenceTreeNode, b: SentenceTreeNode, subst: Subst): boolean {
+    a = deref(a, subst);
+    b = deref(b, subst);
+    if (isVar(a) && isVar(b) && varId(a) === varId(b)) {
+        return true;
+    }
+    if (isVar(a)) {
+        if (occurs(varId(a), b, subst)) return false;
+        subst.set(varId(a), b);
+        return true;
+    }
+    if (isVar(b)) {
+        return unifyTerms(b, a, subst);
+    }
+    if (a.operation !== b.operation) return false;
+    if (a.operation === OperationType.FUNCTIONCALL && a.bound_vars.get(0) !== b.bound_vars.get(0)) {
+        return false;
+    }
+    if (a.children.size !== b.children.size) return false;
+    for (let i = 0; i < a.children.size; i++) {
+        if (!unifyTerms(a.children.get(i)!, b.children.get(i)!, subst)) return false;
+    }
+    return true;
+}
+
+// Atoms are PREDICATECALL or EQUALS nodes. Direct orientation only; callers
+// that want symmetric equality matching try the swapped atom themselves.
+export function unifyAtoms(a: SentenceTreeNode, b: SentenceTreeNode, subst: Subst): boolean {
+    if (a.operation !== b.operation) return false;
+    if (a.operation === OperationType.PREDICATECALL && a.bound_vars.get(0) !== b.bound_vars.get(0)) {
+        return false;
+    }
+    if (a.children.size !== b.children.size) return false;
+    for (let i = 0; i < a.children.size; i++) {
+        if (!unifyTerms(a.children.get(i)!, b.children.get(i)!, subst)) return false;
+    }
+    return true;
+}
+
+export function applySubst(t: SentenceTreeNode, subst: Subst): SentenceTreeNode {
+    if (isVar(t)) {
+        const bound = subst.get(varId(t));
+        return bound === undefined ? t : applySubst(bound, subst);
+    }
+    if (t.children.size === 0) return t;
+    const children = t.children.map((c) => applySubst(c, subst));
+    return S3F({ operation: t.operation, children, bound_vars: t.bound_vars });
+}
+
+export function termSize(t: SentenceTreeNode): number {
+    let size = 1;
+    for (const c of t.children) {
+        size += termSize(c);
+    }
+    return size;
+}

--- a/src/style.css
+++ b/src/style.css
@@ -234,6 +234,161 @@ header h1 {
     transform-origin: 50% 55%;
 }
 
+.prover {
+    margin-top: 2.5rem;
+    border-top: 1px solid var(--border);
+    padding-top: 1.5rem;
+}
+
+.prover h2 {
+    margin: 0 0 0.4rem;
+    font-size: 1.3rem;
+}
+
+.prover h2 .sub {
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: var(--ink-dim);
+    margin-left: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.prover-blurb {
+    color: var(--ink-dim);
+    max-width: 74ch;
+    line-height: 1.5;
+    font-size: 0.92rem;
+    margin: 0 0 1rem;
+}
+
+.prover-controls {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    margin-bottom: 1.2rem;
+}
+
+.prover-controls select {
+    font: inherit;
+    max-width: 100%;
+    background: var(--panel-2);
+    color: var(--ink);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.45rem 0.6rem;
+}
+
+.prover-controls button {
+    font: inherit;
+    font-weight: 600;
+    padding: 0.5rem 1.1rem;
+    border-radius: 10px;
+    border: 1px solid var(--accent);
+    background: var(--panel-2);
+    color: var(--accent);
+    cursor: pointer;
+    transition: transform 0.1s ease, box-shadow 0.2s ease;
+}
+
+.prover-controls button:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 0 12px rgba(98, 182, 255, 0.25);
+}
+
+.prover-controls button:disabled {
+    opacity: 0.45;
+    cursor: default;
+}
+
+.clauses {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+}
+
+.clauses.proof {
+    margin-top: 0.7rem;
+}
+
+.clause-row {
+    display: grid;
+    grid-template-columns: 3rem 1fr 9rem;
+    gap: 0.7rem;
+    align-items: baseline;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 0.45rem 0.9rem;
+}
+
+.proof .clause-row {
+    border-color: #3d4a63;
+    background: var(--panel-2);
+}
+
+.clause-num {
+    color: var(--accent);
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
+.clause-src {
+    color: var(--ink-dim);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    text-align: right;
+}
+
+.glyphs-clause {
+    font-size: 1.1rem;
+    line-height: 1.7;
+    min-height: 1.7em;
+}
+
+.step-info {
+    grid-column: 2 / 4;
+    color: var(--accent-2);
+    font-size: 0.82rem;
+    opacity: 0;
+    transition: opacity 0.5s ease;
+}
+
+.step-info.visible {
+    opacity: 1;
+}
+
+.pop-in {
+    animation: pop-in 0.35s ease both;
+}
+
+@keyframes pop-in {
+    from {
+        opacity: 0;
+        transform: translateY(6px) scale(0.98);
+    }
+    to {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+.verdict {
+    margin-top: 1rem;
+    font-weight: 600;
+    min-height: 1.4em;
+}
+
+.verdict.ok {
+    color: var(--good);
+}
+
+.verdict.fail {
+    color: #ff8484;
+}
+
 .symbols {
     margin-top: 2rem;
     color: var(--ink-dim);

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,21 +1,26 @@
-import { Axiom } from './axioms';
+import { Axiom, Conjecture } from './axioms';
 import { animateRow, renderStatic } from './anim/animator';
-import { printPlainSentence } from './anim/plain-printer';
+import { printPlainSentence, variableDisplayName } from './anim/plain-printer';
+import { eq, not, varr } from './notation/builders';
+import { Clause, StepContext, clauseHasEquality, extractClauses } from './notation/cnf';
+import { Proof, ProverEnv, SideRef, prove } from './notation/resolution';
+import { n2SI, ScopedId } from './notation/scope';
 import { SentenceTreeNode } from './notation/sentence-tree-node';
 import { SymbolTable } from './notation/symbol-table';
+import { print_symbol_table } from './notation/symbol-table-printer';
 
 export interface PipelineStep {
     label: string;
     detail: string;
-    transform: (s: SentenceTreeNode) => SentenceTreeNode;
+    transform: (s: SentenceTreeNode, ctx: StepContext) => SentenceTreeNode;
 }
 
 export interface ExampleUI {
     name: string;
     hint: string;
     axioms: Axiom[];
+    conjectures: Conjecture[];
     symbolTable: SymbolTable;
-    symbolTableHtml: string;
 }
 
 const BASE_DURATION_MS = 1500;
@@ -32,9 +37,9 @@ export function setupApp(
     root.innerHTML = `
         <header>
             <h1>vitefolts</h1>
-            <p class="tagline">A first-order logic engine — watch axiom sets morph into negation normal form.
-            Surviving symbols glide along splines; conversions like <span class="hl">∧→∨</span> and
-            <span class="hl">∃→∀</span> animate as reflections.</p>
+            <p class="tagline">A first-order logic engine — watch axiom sets morph into clausal form,
+            then watch a refutation proof unfold. Surviving symbols glide along splines; conversions like
+            <span class="hl">∧→∨</span> and <span class="hl">∃→∀</span> animate as reflections.</p>
         </header>
         <section class="examples" id="examples"></section>
         <p class="hint" id="hint"></p>
@@ -53,6 +58,20 @@ export function setupApp(
             <span class="status" id="status"></span>
         </section>
         <section class="sentences" id="sentences"></section>
+        <section class="prover">
+            <h2>Prove a conjecture <span class="sub">linear resolution + paramodulation</span></h2>
+            <p class="prover-blurb">Pick a conjecture φ. The prover negates it, converts everything to
+            clauses, and searches for the empty clause □ — a refutation of axioms ∧ ¬φ. Each derivation
+            animates: the parent clauses fuse, the resolved literals annihilate, and unified variables
+            morph into their substituted terms.</p>
+            <div class="prover-controls">
+                <select id="conjecture"></select>
+                <button id="btn-prove" type="button">Prove ▸</button>
+            </div>
+            <div class="clauses" id="clauses"></div>
+            <div class="clauses proof" id="proof"></div>
+            <p class="verdict" id="verdict"></p>
+        </section>
         <details class="symbols">
             <summary>Symbol table</summary>
             <div id="symtab"></div>
@@ -72,6 +91,11 @@ export function setupApp(
     const playBtn = root.querySelector<HTMLButtonElement>('#btn-play')!;
     const resetBtn = root.querySelector<HTMLButtonElement>('#btn-reset')!;
     const speedSel = root.querySelector<HTMLSelectElement>('#speed')!;
+    const conjectureSel = root.querySelector<HTMLSelectElement>('#conjecture')!;
+    const proveBtn = root.querySelector<HTMLButtonElement>('#btn-prove')!;
+    const clausesEl = root.querySelector<HTMLElement>('#clauses')!;
+    const proofEl = root.querySelector<HTMLElement>('#proof')!;
+    const verdictEl = root.querySelector<HTMLElement>('#verdict')!;
 
     const exampleTabs: HTMLButtonElement[] = examples.map((ex, k) => {
         const tab = document.createElement('button');
@@ -93,7 +117,7 @@ export function setupApp(
     });
     const doneChip = document.createElement('div');
     doneChip.className = 'chip chip-final';
-    doneChip.textContent = 'negation normal form';
+    doneChip.textContent = 'clausal form';
     pipelineEl.appendChild(doneChip);
 
     let exampleIndex = -1;
@@ -104,9 +128,42 @@ export function setupApp(
     // Bumped whenever state jumps (reset / example switch) so a play-all loop
     // sleeping between steps can't wake up and keep stepping the new state.
     let session = 0;
+    // Working symbol table: starts as the example's table and grows as the
+    // pipeline mints Skolem functions and the prover renames variables.
+    let workingSt: SymbolTable;
+    let skolemCounter = 0;
+    let freshVarCounter = 0;
+
+    const ctx: StepContext = {
+        freshSkolem(arity: number): ScopedId {
+            skolemCounter++;
+            const id = n2SI(0, 500 + skolemCounter);
+            workingSt = workingSt.add_function(id, `σ${skolemCounter}`, arity, false);
+            return id;
+        },
+    };
+
+    const proverEnv: ProverEnv = {
+        freshVar(base: ScopedId): ScopedId {
+            freshVarCounter++;
+            const id = n2SI(3, freshVarCounter);
+            const name = variableDisplayName(base, workingSt) + '′';
+            workingSt = workingSt.add_variable(id, name);
+            return id;
+        },
+    };
 
     function current(): ExampleUI {
         return examples[exampleIndex];
+    }
+
+    function litToString(positive: boolean, atom: SentenceTreeNode): string {
+        return positive ? printPlainSentence(atom, workingSt) : printPlainSentence(not(atom), workingSt);
+    }
+
+    function clauseToString(clause: Clause): string {
+        if (clause.literals.length === 0) return '□';
+        return '{' + clause.literals.map((l) => litToString(l.positive, l.atom)).join(', ') + '}';
     }
 
     function buildRows(axioms: Axiom[]): void {
@@ -128,7 +185,29 @@ export function setupApp(
     }
 
     function renderAll(): void {
-        trees.forEach((tree, k) => renderStatic(rowGlyphEls[k], printPlainSentence(tree, current().symbolTable)));
+        trees.forEach((tree, k) => renderStatic(rowGlyphEls[k], printPlainSentence(tree, workingSt)));
+    }
+
+    function refreshSymtab(): void {
+        symtabEl.innerHTML = print_symbol_table(workingSt);
+    }
+
+    function clearProver(): void {
+        clausesEl.textContent = '';
+        proofEl.textContent = '';
+        verdictEl.textContent = '';
+        verdictEl.className = 'verdict';
+    }
+
+    function populateConjectures(): void {
+        conjectureSel.textContent = '';
+        current().conjectures.forEach((c, k) => {
+            const opt = document.createElement('option');
+            opt.value = String(k);
+            const text = printPlainSentence(c.tree, current().symbolTable);
+            opt.textContent = c.remark ? `${text}   (${c.remark})` : text;
+            conjectureSel.appendChild(opt);
+        });
     }
 
     function updateChrome(): void {
@@ -146,8 +225,10 @@ export function setupApp(
         playBtn.disabled = busy || finished;
         resetBtn.disabled = busy;
         speedSel.disabled = busy;
-        if (finished && !busy) {
-            statusEl.textContent = 'Done — every sentence is in negation normal form.';
+        proveBtn.disabled = busy;
+        conjectureSel.disabled = busy;
+        if (finished && !busy && statusEl.textContent === '') {
+            statusEl.textContent = 'Done — every sentence is in clausal normal form.';
         }
     }
 
@@ -156,11 +237,16 @@ export function setupApp(
         session++;
         exampleIndex = k;
         const ex = current();
+        workingSt = ex.symbolTable;
+        skolemCounter = 0;
+        freshVarCounter = 0;
         trees = ex.axioms.map((a) => a.tree);
         stepIndex = 0;
         statusEl.textContent = '';
         hintEl.textContent = ex.hint;
-        symtabEl.innerHTML = ex.symbolTableHtml;
+        refreshSymtab();
+        clearProver();
+        populateConjectures();
         buildRows(ex.axioms);
         renderAll();
         updateChrome();
@@ -176,10 +262,9 @@ export function setupApp(
         const step = steps[stepIndex];
         statusEl.textContent = step.detail;
         updateChrome();
-        const symbolTable = current().symbolTable;
-        const newTrees = trees.map(step.transform);
-        const newTexts = newTrees.map((t) => printPlainSentence(t, symbolTable));
-        const oldTexts = trees.map((t) => printPlainSentence(t, symbolTable));
+        const newTrees = trees.map((t) => step.transform(t, ctx));
+        const newTexts = newTrees.map((t) => printPlainSentence(t, workingSt));
+        const oldTexts = trees.map((t) => printPlainSentence(t, workingSt));
         const anyChange = newTexts.some((t, k) => t !== oldTexts[k]);
         if (anyChange) {
             const duration = BASE_DURATION_MS * durationMult();
@@ -190,8 +275,12 @@ export function setupApp(
         }
         trees = newTrees;
         stepIndex++;
+        refreshSymtab();
         busy = false;
         updateChrome();
+        if (stepIndex >= steps.length) {
+            statusEl.textContent = 'Done — every sentence is in clausal normal form.';
+        }
     }
 
     async function playAll(): Promise<void> {
@@ -205,16 +294,166 @@ export function setupApp(
     function reset(): void {
         if (busy) return;
         session++;
-        trees = current().axioms.map((a) => a.tree);
+        const ex = current();
+        workingSt = ex.symbolTable;
+        skolemCounter = 0;
+        freshVarCounter = 0;
+        trees = ex.axioms.map((a) => a.tree);
         stepIndex = 0;
         statusEl.textContent = '';
+        refreshSymtab();
+        clearProver();
         renderAll();
         updateChrome();
+    }
+
+    interface NumberedClause {
+        clause: Clause;
+        label: string;
+    }
+
+    function addClauseRow(container: HTMLElement, num: number, label: string, text: string): HTMLElement {
+        const row = document.createElement('div');
+        row.className = 'clause-row pop-in';
+        const numEl = document.createElement('div');
+        numEl.className = 'clause-num';
+        numEl.textContent = `(${num})`;
+        const glyphs = document.createElement('div');
+        glyphs.className = 'glyphs glyphs-clause';
+        const src = document.createElement('div');
+        src.className = 'clause-src';
+        src.textContent = label;
+        row.appendChild(numEl);
+        row.appendChild(glyphs);
+        row.appendChild(src);
+        container.appendChild(row);
+        renderStatic(glyphs, text);
+        return row;
+    }
+
+    function substToString(pairs: Array<[ScopedId, SentenceTreeNode]>): string {
+        if (pairs.length === 0) return 'σ = {}';
+        const parts = pairs.map(([id, term]) =>
+            `${variableDisplayName(id, workingSt)} ↦ ${printPlainSentence(term, workingSt)}`);
+        return `σ = {${parts.join(', ')}}`;
+    }
+
+    async function animateProof(numbered: NumberedClause[], proof: Proof): Promise<void> {
+        const duration = BASE_DURATION_MS * durationMult();
+        // Numbers assigned to derived clauses as they appear.
+        const derivedNums: number[] = [];
+        let nextNum = numbered.length + 1;
+        let centerClause = numbered[proof.startIndex].clause;
+        let centerNum = proof.startIndex + 1;
+
+        const refNum = (ref: SideRef): number => {
+            if (ref.kind === 'input') return ref.index + 1;
+            // derived[0] is the start clause; derived[i] is the resolvent of step i-1.
+            return ref.index === 0 ? proof.startIndex + 1 : derivedNums[ref.index - 1];
+        };
+
+        for (const step of proof.steps) {
+            const num = nextNum++;
+            derivedNums.push(num);
+            const resolventText = clauseToString(step.resolvent);
+            const centerText = clauseToString(centerClause);
+            let startText: string;
+            let info: string;
+            if (step.kind === 'factor') {
+                startText = centerText;
+                info = `factor (${centerNum}) with ${substToString(step.substPairs)}`;
+            } else {
+                const sideText = clauseToString(step.sideRenamed!);
+                startText = `${centerText} ⊗ ${sideText}`;
+                const verb = step.kind === 'paramodulate' ? 'paramodulate' : 'resolve';
+                info = `${verb} (${centerNum}) with (${refNum(step.sideRef!)}), ${substToString(step.substPairs)}`;
+            }
+            const row = addClauseRow(proofEl, num, step.kind, startText);
+            const glyphs = row.querySelector<HTMLElement>('.glyphs')!;
+            const infoEl = document.createElement('div');
+            infoEl.className = 'step-info';
+            row.appendChild(infoEl);
+            await sleep(150 * durationMult());
+            await animateRow(glyphs, resolventText, duration);
+            infoEl.textContent = info;
+            infoEl.classList.add('visible');
+            centerClause = step.resolvent;
+            centerNum = num;
+            await sleep(280 * durationMult());
+        }
+    }
+
+    async function doProve(): Promise<void> {
+        if (busy) return;
+        const conjIndex = parseInt(conjectureSel.value, 10);
+        const conjecture = current().conjectures[conjIndex];
+        if (!conjecture) return;
+        clearProver();
+
+        // Make sure the displayed pipeline has run to clausal form first.
+        const mySession = session;
+        while (stepIndex < steps.length) {
+            await doStep();
+            if (session !== mySession) return;
+        }
+
+        busy = true;
+        updateChrome();
+        statusEl.textContent = '';
+
+        try {
+            // Clausify axioms (already in CNF) and the negated conjecture.
+            const numbered: NumberedClause[] = [];
+            const ex = current();
+            trees.forEach((tree, k) => {
+                for (const clause of extractClauses(tree)) {
+                    numbered.push({ clause, label: ex.axioms[k].note });
+                }
+            });
+            let negated = not(conjecture.tree);
+            for (const step of steps) {
+                negated = step.transform(negated, ctx);
+            }
+            const sosIndices: number[] = [];
+            for (const clause of extractClauses(negated)) {
+                sosIndices.push(numbered.length);
+                numbered.push({ clause, label: '¬ conjecture' });
+            }
+            if (numbered.some((n) => clauseHasEquality(n.clause))) {
+                const x = n2SI(1, 0);
+                numbered.push({ clause: { literals: [{ positive: true, atom: eq(varr(x), varr(x)) }] }, label: 'reflexivity' });
+            }
+            refreshSymtab();
+
+            verdictEl.textContent = `Refuting: axioms ∧ ¬(${printPlainSentence(conjecture.tree, ex.symbolTable)}) — searching for □ …`;
+            for (let i = 0; i < numbered.length; i++) {
+                addClauseRow(clausesEl, i + 1, numbered[i].label, clauseToString(numbered[i].clause));
+                await sleep(90 * durationMult());
+            }
+
+            const proof = prove(numbered.map((n) => n.clause), sosIndices, proverEnv);
+            if (proof === null) {
+                verdictEl.textContent = '✗ No refutation found within the search limits — the conjecture does not follow from these axioms (or needs a deeper proof).';
+                verdictEl.className = 'verdict fail';
+            } else {
+                await animateProof(numbered, proof);
+                verdictEl.textContent = `□ Empty clause derived in ${proof.steps.length} step${proof.steps.length === 1 ? '' : 's'} — contradiction. The conjecture is a theorem.`;
+                verdictEl.className = 'verdict ok';
+            }
+        } catch (err) {
+            verdictEl.textContent = `✗ Prover error: ${err instanceof Error ? err.message : String(err)}`;
+            verdictEl.className = 'verdict fail';
+            throw err;
+        } finally {
+            busy = false;
+            updateChrome();
+        }
     }
 
     stepBtn.addEventListener('click', () => { void doStep(); });
     playBtn.addEventListener('click', () => { void playAll(); });
     resetBtn.addEventListener('click', reset);
+    proveBtn.addEventListener('click', () => { void doProve(); });
 
     selectExample(0);
 }


### PR DESCRIPTION
Extends the pipeline to full clausal form and adds an animated theorem prover.

**Pipeline**: three new animated steps — Skolemize ∃ (fresh σₖ functions of the enclosing ∀-variables, registered live in the symbol table), drop ∀, distribute ∨ over ∧ — so Play-all now ends at clausal normal form.

**Prover**: pick a conjecture φ; the engine refutes axioms ∧ ¬φ by linear resolution with paramodulation — unification with occurs check, binary resolution, factoring, and equality rewriting, searched by iterative-deepening DFS (smallest resolvents first) so the shortest proof is found. A reflexivity clause x=x is added automatically when equality is present.

**Animation**: each derivation reuses the glyph engine — the parent clauses fuse (center ⊗ side), complementary literals annihilate, unified variables morph into their substituted terms, ending at □, with the mgu displayed per step (σ = {x′ ↦ 0}).

**Conjectures** per example, each exercising a different rule:
- Peano: `∃x.NAT(succ(x))`, `NAT(0+0)` (genuine paramodulation), `NAT(1)` (via the succ(0) definition)
- Group: `e·(e·e)=e` (paramodulation), `∃y.e·y=e`
- Socrates: `MORTAL(socrates)`, `¬GOD(socrates)`, and `GOD(socrates)` — an honest search failure
- Interlock: `RUN → ¬ALARM`, `A_OK ∨ FAULT`

Verified headlessly: all 10 conjectures produce the expected verdict (9 proofs with correct σ chains, 1 correct failure), zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)