### PR TITLE
Formula editor: build your own axiom sets and conjectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Then **prove a conjecture**: pick a conjecture φ and the engine refutes axioms ∧ ¬φ by **linear resolution with paramodulation** — unification with occurs check, binary resolution, factoring, and equality rewriting, searched by iterative deepening so the shortest proof is found. Every derivation animates with the same glyph engine: the parent clauses fuse, the resolved complementary literals annihilate, and unified variables visibly morph into their substituted terms, ending at the empty clause `□`. Conjectures that don't follow (try `GOD(socrates)`) report an honest search failure.
 
+And **build your own theory**: the **Custom ✎** tab has a formula editor — axioms and conjectures, one per line, with optional `label:` prefixes and `#` comments. The parser accepts exactly what the app displays (so `✎ edit in editor` copies any built-in example in for tweaking, verified round-trip) plus ASCII aliases: `forall`, `exists`, `~`, `&`, `|`, `->`, `<-`, `<->`, `*`. Symbol roles and arities are inferred from use — names applied in formula position are predicates, in term position functions; bare `u`–`z` or quantifier-bound names are variables, anything else is a constant. A typed-conjecture box next to the menu lets you pose your own question on any example.
+
 Four example theories are included, each chosen so a different pipeline step gets a dramatic moment:
 
 - **Peano arithmetic** — the classic axioms, plus a `¬∃x.[NAT(x)]∧[succ(x)=0]` row that double-flips under De Morgan.

--- a/src/notation/parser.ts
+++ b/src/notation/parser.ts
@@ -1,0 +1,422 @@
+import { List } from 'immutable';
+import { and, eq, exists, fn, forall, iff, implies, not, or, pred, varr } from './builders';
+import { OperationType } from './operation-type';
+import { getName, getScope, n2SI, ScopedId } from './scope';
+import { S3, SentenceTreeNode } from './sentence-tree-node';
+import { SymbolTable } from './symbol-table';
+import { SymbolType } from './symbol-type';
+
+// Text parser for first-order formulas. The grammar accepts exactly what
+// plain-printer.ts emits — so any displayed sentence can be pasted back in —
+// plus ASCII aliases for every symbol:
+//   ∀/forall  ∃/exists  ¬/~  ∧/&  ∨/|  →/->  ←/<-  ↔/<->  ·/*
+// Symbol roles are inferred from usage: a name applied in formula position is
+// a predicate, in term position a function; bare names are variables when
+// quantifier-bound or single letters u–z, otherwise constants.
+
+export class ParseError extends Error {}
+
+interface Token {
+    kind: 'id' | 'op';
+    value: string;
+    pos: number;
+}
+
+const OP_ALIASES: Array<[string, string]> = [
+    ['<->', '↔'], ['->', '→'], ['<-', '←'],
+    ['~', '¬'], ['&', '∧'], ['|', '∨'], ['*', '·'],
+];
+const SINGLE_OPS = new Set(['∀', '∃', '¬', '∧', '∨', '→', '←', '↔', '=', '(', ')', '[', ']', '.', ',', '·', '+', '-', '/']);
+const KEYWORDS = new Map<string, string>([['forall', '∀'], ['exists', '∃']]);
+const INFIX_TERM_OPS = new Set(['·', '+', '-', '/']);
+
+function tokenize(text: string): Token[] {
+    const tokens: Token[] = [];
+    let i = 0;
+    outer: while (i < text.length) {
+        const ch = text[i];
+        if (/\s/.test(ch)) { i++; continue; }
+        for (const [alias, canon] of OP_ALIASES) {
+            if (text.startsWith(alias, i)) {
+                tokens.push({ kind: 'op', value: canon, pos: i });
+                i += alias.length;
+                continue outer;
+            }
+        }
+        if (SINGLE_OPS.has(ch)) {
+            tokens.push({ kind: 'op', value: ch, pos: i });
+            i++;
+            continue;
+        }
+        const m = /^[A-Za-z0-9_]+/.exec(text.slice(i));
+        if (m) {
+            const word = m[0];
+            const kw = KEYWORDS.get(word.toLowerCase());
+            if (kw !== undefined) {
+                tokens.push({ kind: 'op', value: kw, pos: i });
+            } else {
+                tokens.push({ kind: 'id', value: word, pos: i });
+            }
+            i += word.length;
+            continue;
+        }
+        throw new ParseError(`Unexpected character “${ch}” at position ${i + 1}`);
+    }
+    return tokens;
+}
+
+// Untyped syntax tree, before symbol roles are resolved.
+type UTerm =
+    | { k: 'name'; name: string }
+    | { k: 'call'; name: string; args: UTerm[] }
+    | { k: 'infix'; op: string; l: UTerm; r: UTerm };
+
+type UForm =
+    | { k: 'iff' | 'imp' | 'limp'; a: UForm; b: UForm }
+    | { k: 'and' | 'or'; items: UForm[] }
+    | { k: 'not'; a: UForm }
+    | { k: 'forall' | 'exists'; vars: string[]; body: UForm }
+    | { k: 'eq'; l: UTerm; r: UTerm }
+    | { k: 'atom'; name: string; args: UTerm[] };
+
+class TokenStream {
+    tokens: Token[];
+    pos = 0;
+    constructor(text: string) {
+        this.tokens = tokenize(text);
+    }
+    peek(): Token | undefined {
+        return this.tokens[this.pos];
+    }
+    peekOp(value: string): boolean {
+        const t = this.peek();
+        return t !== undefined && t.kind === 'op' && t.value === value;
+    }
+    takeOp(value: string): boolean {
+        if (this.peekOp(value)) { this.pos++; return true; }
+        return false;
+    }
+    expectOp(value: string): void {
+        if (!this.takeOp(value)) {
+            const t = this.peek();
+            throw new ParseError(`Expected “${value}”${t ? ` but found “${t.value}”` : ' but the formula ended'}`);
+        }
+    }
+    takeId(): string {
+        const t = this.peek();
+        if (t === undefined || t.kind !== 'id') {
+            throw new ParseError(`Expected a name${t ? ` but found “${t.value}”` : ' but the formula ended'}`);
+        }
+        this.pos++;
+        return t.value;
+    }
+    atEnd(): boolean {
+        return this.pos >= this.tokens.length;
+    }
+}
+
+function parseArgs(s: TokenStream): UTerm[] {
+    const args: UTerm[] = [];
+    if (s.takeOp(')')) return args;
+    for (;;) {
+        args.push(parseUTerm(s));
+        if (s.takeOp(')')) return args;
+        s.expectOp(',');
+    }
+}
+
+function parseUFactor(s: TokenStream): UTerm {
+    if (s.takeOp('(')) {
+        const t = parseUTerm(s);
+        s.expectOp(')');
+        return t;
+    }
+    const name = s.takeId();
+    if (s.takeOp('(')) {
+        return { k: 'call', name, args: parseArgs(s) };
+    }
+    return { k: 'name', name };
+}
+
+function parseUTerm(s: TokenStream): UTerm {
+    let left = parseUFactor(s);
+    for (;;) {
+        const t = s.peek();
+        if (t === undefined || t.kind !== 'op' || !INFIX_TERM_OPS.has(t.value)) return left;
+        s.pos++;
+        left = { k: 'infix', op: t.value, l: left, r: parseUFactor(s) };
+    }
+}
+
+function parseAtomOrParen(s: TokenStream): UForm {
+    // Try `term = term` first (the lhs may itself start with a parenthesis,
+    // as in (x·y)·z = x·(y·z)), backtracking if no “=” materializes.
+    const save = s.pos;
+    try {
+        const l = parseUTerm(s);
+        if (s.takeOp('=')) {
+            return { k: 'eq', l, r: parseUTerm(s) };
+        }
+    } catch {
+        // fall through to the other alternatives
+    }
+    s.pos = save;
+    if (s.takeOp('(')) {
+        const inner = parseUForm(s);
+        s.expectOp(')');
+        return inner;
+    }
+    if (s.takeOp('[')) {
+        const inner = parseUForm(s);
+        s.expectOp(']');
+        return inner;
+    }
+    const name = s.takeId();
+    if (s.takeOp('(')) {
+        return { k: 'atom', name, args: parseArgs(s) };
+    }
+    return { k: 'atom', name, args: [] };
+}
+
+function parseUnary(s: TokenStream): UForm {
+    if (s.takeOp('¬')) {
+        return { k: 'not', a: parseUnary(s) };
+    }
+    if (s.peekOp('∀') || s.peekOp('∃')) {
+        const which = s.peek()!.value === '∀' ? 'forall' : 'exists';
+        s.pos++;
+        const vars = [s.takeId()];
+        while (s.takeOp(',')) vars.push(s.takeId());
+        s.expectOp('.');
+        // Quantifier bodies extend as far to the right as possible.
+        return { k: which, vars, body: parseUForm(s) };
+    }
+    return parseAtomOrParen(s);
+}
+
+function parseConj(s: TokenStream): UForm {
+    const items = [parseUnary(s)];
+    while (s.takeOp('∧')) items.push(parseUnary(s));
+    return items.length === 1 ? items[0] : { k: 'and', items };
+}
+
+function parseDisj(s: TokenStream): UForm {
+    const items = [parseConj(s)];
+    while (s.takeOp('∨')) items.push(parseConj(s));
+    return items.length === 1 ? items[0] : { k: 'or', items };
+}
+
+function parseImp(s: TokenStream): UForm {
+    const parts: UForm[] = [parseDisj(s)];
+    const ops: string[] = [];
+    while (s.peekOp('→') || s.peekOp('←')) {
+        ops.push(s.peek()!.value);
+        s.pos++;
+        parts.push(parseDisj(s));
+    }
+    if (ops.length === 0) return parts[0];
+    if (ops.some((o) => o !== ops[0])) {
+        throw new ParseError('Mixed → and ← without parentheses — please add parentheses');
+    }
+    if (ops[0] === '→') {
+        // Right-associative: A → B → C means A → (B → C).
+        let result = parts[parts.length - 1];
+        for (let i = parts.length - 2; i >= 0; i--) {
+            result = { k: 'imp', a: parts[i], b: result };
+        }
+        return result;
+    }
+    let result = parts[0];
+    for (let i = 1; i < parts.length; i++) {
+        result = { k: 'limp', a: result, b: parts[i] };
+    }
+    return result;
+}
+
+function parseUForm(s: TokenStream): UForm {
+    let left = parseImp(s);
+    while (s.takeOp('↔')) {
+        left = { k: 'iff', a: left, b: parseImp(s) };
+    }
+    return left;
+}
+
+// ---------------------------------------------------------------------------
+// Symbol resolution: assign predicate/function/variable roles and ids.
+
+interface SymbolInfo {
+    id: ScopedId;
+    kind: 'predicate' | 'function';
+    arity: number;
+    infix: boolean;
+}
+
+interface NewSymbol {
+    id: ScopedId;
+    name: string;
+    kind: 'predicate' | 'function' | 'variable';
+    arity: number;
+    infix: boolean;
+}
+
+function isVariableName(name: string): boolean {
+    return /^[u-z]$/.test(name);
+}
+
+export class Registry {
+    private symbols = new Map<string, SymbolInfo>();
+    private freeVarIds = new Map<string, ScopedId>();
+    private additions: NewSymbol[] = [];
+    private nextSymbolNum = 0;
+    private nextVarNum = 0;
+    private usedSymbolNums = new Set<number>();
+    private usedVarNums = new Set<number>();
+
+    static fromSymbolTable(st: SymbolTable): Registry {
+        const reg = new Registry();
+        for (const entry of st.all_entries()) {
+            if (getScope(entry.id) === 1) {
+                // Variables registered by earlier parses — never reuse their ids.
+                reg.usedVarNums.add(Number(getName(entry.id)));
+                continue;
+            }
+            const kind = entry.stype === SymbolType.PREDICATE ? 'predicate'
+                : entry.stype === SymbolType.FUNCTION ? 'function' : null;
+            if (kind === null) continue;
+            reg.symbols.set(entry.name, { id: entry.id, kind, arity: entry.arity, infix: entry.is_infix });
+            if (getScope(entry.id) === 0) {
+                reg.usedSymbolNums.add(Number(getName(entry.id)));
+            }
+        }
+        // Keep clear of the anonymous x/y/z ids the built-in examples use.
+        reg.nextVarNum = 50;
+        return reg;
+    }
+
+    newSymbols(): NewSymbol[] {
+        return this.additions;
+    }
+
+    private allocSymbolId(): ScopedId {
+        while (this.usedSymbolNums.has(this.nextSymbolNum)) this.nextSymbolNum++;
+        this.usedSymbolNums.add(this.nextSymbolNum);
+        return n2SI(0, this.nextSymbolNum);
+    }
+
+    lookup(name: string, kind: 'predicate' | 'function', arity: number, infix: boolean): ScopedId {
+        const existing = this.symbols.get(name);
+        if (existing !== undefined) {
+            if (existing.kind !== kind || existing.arity !== arity) {
+                throw new ParseError(
+                    `“${name}” is used as a ${kind} with ${arity} argument(s) but was already a ${existing.kind} with ${existing.arity}`);
+            }
+            return existing.id;
+        }
+        const id = this.allocSymbolId();
+        this.symbols.set(name, { id, kind, arity, infix });
+        this.additions.push({ id, name, kind, arity, infix });
+        return id;
+    }
+
+    private allocVarId(): ScopedId {
+        while (this.usedVarNums.has(this.nextVarNum)) this.nextVarNum++;
+        this.usedVarNums.add(this.nextVarNum);
+        return n2SI(1, this.nextVarNum);
+    }
+
+    freeVar(name: string): ScopedId {
+        const existing = this.freeVarIds.get(name);
+        if (existing !== undefined) return existing;
+        const id = this.allocVarId();
+        this.freeVarIds.set(name, id);
+        this.additions.push({ id, name, kind: 'variable', arity: 0, infix: false });
+        return id;
+    }
+
+    boundVar(name: string): ScopedId {
+        const id = this.allocVarId();
+        this.additions.push({ id, name, kind: 'variable', arity: 0, infix: false });
+        return id;
+    }
+
+    // Register every symbol this registry has allocated into a symbol table.
+    applyTo(st: SymbolTable): SymbolTable {
+        for (const s of this.additions) {
+            if (s.kind === 'predicate') st = st.add_predicate(s.id, s.name, s.arity, s.infix);
+            else if (s.kind === 'function') st = st.add_function(s.id, s.name, s.arity, s.infix);
+            else st = st.add_variable(s.id, s.name);
+        }
+        return st;
+    }
+}
+
+function resolveTerm(t: UTerm, reg: Registry, bound: Map<string, ScopedId>): SentenceTreeNode {
+    switch (t.k) {
+        case 'name': {
+            const boundId = bound.get(t.name);
+            if (boundId !== undefined) return varr(boundId);
+            if (isVariableName(t.name)) return varr(reg.freeVar(t.name));
+            return fn(reg.lookup(t.name, 'function', 0, false));
+        }
+        case 'call':
+            return fn(reg.lookup(t.name, 'function', t.args.length, false),
+                ...t.args.map((a) => resolveTerm(a, reg, bound)));
+        case 'infix':
+            return fn(reg.lookup(t.op, 'function', 2, true),
+                resolveTerm(t.l, reg, bound), resolveTerm(t.r, reg, bound));
+    }
+}
+
+function resolveForm(f: UForm, reg: Registry, bound: Map<string, ScopedId>): SentenceTreeNode {
+    switch (f.k) {
+        case 'iff':
+            return iff(resolveForm(f.a, reg, bound), resolveForm(f.b, reg, bound));
+        case 'imp':
+            return implies(resolveForm(f.a, reg, bound), resolveForm(f.b, reg, bound));
+        case 'limp':
+            return S3(OperationType.LIMP,
+                List([resolveForm(f.a, reg, bound), resolveForm(f.b, reg, bound)]), List([]));
+        case 'and':
+            return and(...f.items.map((i) => resolveForm(i, reg, bound)));
+        case 'or':
+            return or(...f.items.map((i) => resolveForm(i, reg, bound)));
+        case 'not':
+            return not(resolveForm(f.a, reg, bound));
+        case 'forall':
+        case 'exists': {
+            const inner = new Map(bound);
+            const ids = f.vars.map((name) => {
+                const id = reg.boundVar(name);
+                inner.set(name, id);
+                return id;
+            });
+            const body = resolveForm(f.body, reg, inner);
+            return f.k === 'forall' ? forall(ids, body) : exists(ids, body);
+        }
+        case 'eq':
+            return eq(resolveTerm(f.l, reg, bound), resolveTerm(f.r, reg, bound));
+        case 'atom': {
+            if (f.args.length === 0) {
+                const boundId = bound.get(f.name);
+                if (boundId !== undefined || isVariableName(f.name)) {
+                    throw new ParseError(`“${f.name}” is a variable — a formula cannot be a bare variable`);
+                }
+            }
+            return pred(reg.lookup(f.name, 'predicate', f.args.length, false),
+                ...f.args.map((a) => resolveTerm(a, reg, bound)));
+        }
+    }
+}
+
+export function parseSentence(text: string, reg: Registry): SentenceTreeNode {
+    const s = new TokenStream(text);
+    if (s.atEnd()) {
+        throw new ParseError('Empty formula');
+    }
+    const form = parseUForm(s);
+    if (!s.atEnd()) {
+        const t = s.peek()!;
+        throw new ParseError(`Unexpected “${t.value}” after the end of the formula`);
+    }
+    return resolveForm(form, reg, new Map());
+}

--- a/src/style.css
+++ b/src/style.css
@@ -96,6 +96,155 @@ header h1 {
     min-height: 2.2em;
 }
 
+.ex-edit {
+    border-style: dashed;
+    color: var(--accent-2);
+}
+
+.ex-edit:hover:not(:disabled) {
+    color: var(--accent-2);
+    border-color: var(--accent-2);
+}
+
+.editor[hidden] {
+    display: none;
+}
+
+.editor {
+    display: grid;
+    grid-template-columns: 3fr 2fr;
+    gap: 1rem;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1rem;
+    margin-bottom: 1.2rem;
+}
+
+.editor-col {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    min-width: 0;
+}
+
+.editor-col label {
+    color: var(--ink-dim);
+    font-size: 0.82rem;
+}
+
+.symbar {
+    display: flex;
+    gap: 0.25rem;
+    flex-wrap: wrap;
+}
+
+.symbar button {
+    font-family: "STIX Two Math", "Cambria Math", "Noto Sans Math", serif;
+    font-size: 1rem;
+    line-height: 1;
+    padding: 0.25rem 0.5rem;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--panel-2);
+    color: var(--ink);
+    cursor: pointer;
+}
+
+.symbar button:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.editor textarea {
+    font-family: "STIX Two Math", "Cambria Math", "Noto Sans Math", ui-monospace, monospace;
+    font-size: 0.98rem;
+    line-height: 1.6;
+    background: var(--bg);
+    color: var(--ink);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.6rem 0.7rem;
+    resize: vertical;
+    min-height: 4em;
+}
+
+.editor textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.editor-actions {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    flex-wrap: wrap;
+}
+
+.editor-actions button {
+    font: inherit;
+    font-weight: 600;
+    padding: 0.45rem 1rem;
+    border-radius: 10px;
+    border: 1px solid var(--accent-2);
+    background: var(--panel-2);
+    color: var(--accent-2);
+    cursor: pointer;
+}
+
+.editor-actions button:hover:not(:disabled) {
+    box-shadow: 0 0 12px rgba(255, 196, 107, 0.25);
+}
+
+.editor-actions button:disabled {
+    opacity: 0.45;
+    cursor: default;
+}
+
+.editor-help {
+    color: var(--ink-dim);
+    font-size: 0.78rem;
+    line-height: 1.5;
+    max-width: 60ch;
+}
+
+.editor-error {
+    grid-column: 1 / -1;
+    margin: 0;
+    color: #ff8484;
+    font-size: 0.85rem;
+    white-space: pre-wrap;
+    font-family: inherit;
+}
+
+.editor-error:empty {
+    display: none;
+}
+
+#conj-typed {
+    font: inherit;
+    font-family: "STIX Two Math", "Cambria Math", "Noto Sans Math", ui-monospace, monospace;
+    flex: 1;
+    min-width: 16rem;
+    background: var(--bg);
+    color: var(--ink);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.45rem 0.6rem;
+}
+
+#conj-typed:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+@media (max-width: 860px) {
+    .editor {
+        grid-template-columns: 1fr;
+    }
+}
+
 .pipeline {
     display: flex;
     flex-wrap: wrap;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -3,6 +3,7 @@ import { animateRow, renderStatic } from './anim/animator';
 import { printPlainSentence, variableDisplayName } from './anim/plain-printer';
 import { eq, not, varr } from './notation/builders';
 import { Clause, StepContext, clauseHasEquality, extractClauses } from './notation/cnf';
+import { ParseError, Registry, parseSentence } from './notation/parser';
 import { Proof, ProverEnv, SideRef, prove } from './notation/resolution';
 import { n2SI, ScopedId } from './notation/scope';
 import { SentenceTreeNode } from './notation/sentence-tree-node';
@@ -29,6 +30,72 @@ function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const STARTER_AXIOMS = `parent: PARENT(alice, bob)
+parent: PARENT(bob, carol)
+grandparent rule: [PARENT(x,y)]∧[PARENT(y,z)] → GRAND(x,z)`;
+
+const STARTER_CONJECTURES = `GRAND(alice, carol)
+∃z.GRAND(alice, z)
+GRAND(carol, alice)  # not entailed — watch the search fail`;
+
+const CUSTOM_HINT = 'Your own theory. Edit the axioms and conjectures below, hit Apply, then step the pipeline or prove a conjecture. Use “✎ edit in editor” on any example to start from it.';
+
+interface SplitLine {
+    formula: string;
+    label: string;
+    comment: string;
+}
+
+function splitLine(raw: string): SplitLine {
+    let body = raw;
+    let comment = '';
+    const hash = body.indexOf('#');
+    if (hash !== -1) {
+        comment = body.slice(hash + 1).trim();
+        body = body.slice(0, hash);
+    }
+    let label = '';
+    const colon = body.indexOf(':');
+    if (colon !== -1) {
+        label = body.slice(0, colon).trim();
+        body = body.slice(colon + 1);
+    }
+    return { formula: body.trim(), label, comment };
+}
+
+function parseTheory(axText: string, conjText: string): ExampleUI {
+    const reg = new Registry();
+    const axioms: Axiom[] = [];
+    const conjectures: Conjecture[] = [];
+    const errors: string[] = [];
+    axText.split('\n').forEach((raw, ln) => {
+        const { formula, label } = splitLine(raw);
+        if (formula === '') return;
+        try {
+            axioms.push({ tree: parseSentence(formula, reg), note: label });
+        } catch (err) {
+            errors.push(`Axiom line ${ln + 1}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    });
+    conjText.split('\n').forEach((raw, ln) => {
+        const { formula, comment } = splitLine(raw);
+        if (formula === '') return;
+        try {
+            conjectures.push({ tree: parseSentence(formula, reg), remark: comment || undefined });
+        } catch (err) {
+            errors.push(`Conjecture line ${ln + 1}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    });
+    if (errors.length > 0) {
+        throw new ParseError(errors.join('\n'));
+    }
+    if (axioms.length === 0) {
+        throw new ParseError('The theory needs at least one axiom.');
+    }
+    const symbolTable = reg.applyTo(new SymbolTable());
+    return { name: 'Custom ✎', hint: CUSTOM_HINT, axioms, conjectures, symbolTable };
+}
+
 export function setupApp(
     root: HTMLElement,
     examples: ExampleUI[],
@@ -43,6 +110,23 @@ export function setupApp(
         </header>
         <section class="examples" id="examples"></section>
         <p class="hint" id="hint"></p>
+        <section class="editor" id="editor" hidden>
+            <div class="editor-col">
+                <label for="ax-input">Axioms — one per line, optionally “label: formula”, # comments</label>
+                <div class="symbar" data-for="ax-input"></div>
+                <textarea id="ax-input" rows="8" spellcheck="false"></textarea>
+            </div>
+            <div class="editor-col">
+                <label for="conj-input">Conjectures — one per line</label>
+                <div class="symbar" data-for="conj-input"></div>
+                <textarea id="conj-input" rows="4" spellcheck="false"></textarea>
+            </div>
+            <div class="editor-actions">
+                <button id="btn-apply" type="button">Apply theory ▸</button>
+                <span class="editor-help">ASCII aliases: forall, exists, ~, &amp;, |, -&gt;, &lt;-&gt;, * · Variables are u–z or quantifier-bound; other names are constants/functions/predicates, inferred from use.</span>
+            </div>
+            <pre class="editor-error" id="editor-error"></pre>
+        </section>
         <section class="pipeline" id="pipeline"></section>
         <section class="controls">
             <button id="btn-step" type="button">Step ▸</button>
@@ -66,6 +150,8 @@ export function setupApp(
             morph into their substituted terms.</p>
             <div class="prover-controls">
                 <select id="conjecture"></select>
+                <input id="conj-typed" type="text" spellcheck="false"
+                    placeholder="… or type your own, e.g. ∃x.MORTAL(x)" />
                 <button id="btn-prove" type="button">Prove ▸</button>
             </div>
             <div class="clauses" id="clauses"></div>
@@ -92,20 +178,52 @@ export function setupApp(
     const resetBtn = root.querySelector<HTMLButtonElement>('#btn-reset')!;
     const speedSel = root.querySelector<HTMLSelectElement>('#speed')!;
     const conjectureSel = root.querySelector<HTMLSelectElement>('#conjecture')!;
+    const conjTypedInput = root.querySelector<HTMLInputElement>('#conj-typed')!;
     const proveBtn = root.querySelector<HTMLButtonElement>('#btn-prove')!;
     const clausesEl = root.querySelector<HTMLElement>('#clauses')!;
     const proofEl = root.querySelector<HTMLElement>('#proof')!;
     const verdictEl = root.querySelector<HTMLElement>('#verdict')!;
+    const editorEl = root.querySelector<HTMLElement>('#editor')!;
+    const axInput = root.querySelector<HTMLTextAreaElement>('#ax-input')!;
+    const conjInput = root.querySelector<HTMLTextAreaElement>('#conj-input')!;
+    const applyBtn = root.querySelector<HTMLButtonElement>('#btn-apply')!;
+    const editorErrEl = root.querySelector<HTMLElement>('#editor-error')!;
 
-    const exampleTabs: HTMLButtonElement[] = examples.map((ex, k) => {
+    const allExamples: ExampleUI[] = [...examples, parseTheory(STARTER_AXIOMS, STARTER_CONJECTURES)];
+    const customIndex = allExamples.length - 1;
+    axInput.value = STARTER_AXIOMS;
+    conjInput.value = STARTER_CONJECTURES;
+
+    const exampleTabs: HTMLButtonElement[] = allExamples.map((ex, k) => {
         const tab = document.createElement('button');
         tab.type = 'button';
         tab.className = 'ex-tab';
         tab.textContent = ex.name;
-        tab.addEventListener('click', () => selectExample(k));
+        tab.addEventListener('click', () => loadExample(k));
         examplesEl.appendChild(tab);
         return tab;
     });
+    const editBtn = document.createElement('button');
+    editBtn.type = 'button';
+    editBtn.className = 'ex-tab ex-edit';
+    editBtn.textContent = '✎ edit in editor';
+    editBtn.title = 'Copy the current example into the Custom editor';
+    examplesEl.appendChild(editBtn);
+
+    for (const bar of Array.from(root.querySelectorAll<HTMLElement>('.symbar'))) {
+        const target = root.querySelector<HTMLTextAreaElement>(`#${bar.dataset.for}`)!;
+        for (const sym of ['∀', '∃', '¬', '∧', '∨', '→', '↔', '=', '·']) {
+            const b = document.createElement('button');
+            b.type = 'button';
+            b.textContent = sym;
+            b.addEventListener('click', () => {
+                const at = target.selectionStart ?? target.value.length;
+                target.setRangeText(sym, at, target.selectionEnd ?? at, 'end');
+                target.focus();
+            });
+            bar.appendChild(b);
+        }
+    }
 
     const chips: HTMLElement[] = steps.map((step) => {
         const chip = document.createElement('div');
@@ -154,7 +272,7 @@ export function setupApp(
     };
 
     function current(): ExampleUI {
-        return examples[exampleIndex];
+        return allExamples[exampleIndex];
     }
 
     function litToString(positive: boolean, atom: SentenceTreeNode): string {
@@ -201,6 +319,13 @@ export function setupApp(
 
     function populateConjectures(): void {
         conjectureSel.textContent = '';
+        if (current().conjectures.length === 0) {
+            const opt = document.createElement('option');
+            opt.value = '';
+            opt.textContent = '— no conjectures defined —';
+            conjectureSel.appendChild(opt);
+            return;
+        }
         current().conjectures.forEach((c, k) => {
             const opt = document.createElement('option');
             opt.value = String(k);
@@ -227,13 +352,16 @@ export function setupApp(
         speedSel.disabled = busy;
         proveBtn.disabled = busy;
         conjectureSel.disabled = busy;
+        conjTypedInput.disabled = busy;
+        applyBtn.disabled = busy;
+        editBtn.disabled = busy;
         if (finished && !busy && statusEl.textContent === '') {
             statusEl.textContent = 'Done — every sentence is in clausal normal form.';
         }
     }
 
-    function selectExample(k: number): void {
-        if (busy || k === exampleIndex) return;
+    function loadExample(k: number, force = false): void {
+        if (busy || (!force && k === exampleIndex)) return;
         session++;
         exampleIndex = k;
         const ex = current();
@@ -244,12 +372,48 @@ export function setupApp(
         stepIndex = 0;
         statusEl.textContent = '';
         hintEl.textContent = ex.hint;
+        editorEl.hidden = k !== customIndex;
+        conjTypedInput.value = '';
         refreshSymtab();
         clearProver();
         populateConjectures();
         buildRows(ex.axioms);
         renderAll();
         updateChrome();
+    }
+
+    function serializeAxioms(ex: ExampleUI): string {
+        return ex.axioms
+            .map((a) => (a.note ? `${a.note}: ` : '') + printPlainSentence(a.tree, ex.symbolTable))
+            .join('\n');
+    }
+
+    function serializeConjectures(ex: ExampleUI): string {
+        return ex.conjectures
+            .map((c) => printPlainSentence(c.tree, ex.symbolTable) + (c.remark ? `  # ${c.remark}` : ''))
+            .join('\n');
+    }
+
+    function applyEditor(): void {
+        if (busy) return;
+        try {
+            allExamples[customIndex] = parseTheory(axInput.value, conjInput.value);
+            editorErrEl.textContent = '';
+            loadExample(customIndex, true);
+        } catch (err) {
+            if (exampleIndex !== customIndex) {
+                loadExample(customIndex, true);
+            }
+            editorErrEl.textContent = err instanceof Error ? err.message : String(err);
+        }
+    }
+
+    function editCurrentExample(): void {
+        if (busy) return;
+        const ex = current();
+        axInput.value = serializeAxioms(ex);
+        conjInput.value = serializeConjectures(ex);
+        applyEditor();
     }
 
     function durationMult(): number {
@@ -385,9 +549,27 @@ export function setupApp(
 
     async function doProve(): Promise<void> {
         if (busy) return;
-        const conjIndex = parseInt(conjectureSel.value, 10);
-        const conjecture = current().conjectures[conjIndex];
-        if (!conjecture) return;
+        let conjTree: SentenceTreeNode;
+        const typed = conjTypedInput.value.trim();
+        if (typed !== '') {
+            try {
+                const reg = Registry.fromSymbolTable(workingSt);
+                conjTree = parseSentence(typed, reg);
+                workingSt = reg.applyTo(workingSt);
+            } catch (err) {
+                verdictEl.textContent = `✗ Could not parse the conjecture: ${err instanceof Error ? err.message : String(err)}`;
+                verdictEl.className = 'verdict fail';
+                return;
+            }
+        } else {
+            const conjecture = current().conjectures[parseInt(conjectureSel.value, 10)];
+            if (!conjecture) {
+                verdictEl.textContent = 'Pick a conjecture from the menu or type one first.';
+                verdictEl.className = 'verdict';
+                return;
+            }
+            conjTree = conjecture.tree;
+        }
         clearProver();
 
         // Make sure the displayed pipeline has run to clausal form first.
@@ -410,7 +592,7 @@ export function setupApp(
                     numbered.push({ clause, label: ex.axioms[k].note });
                 }
             });
-            let negated = not(conjecture.tree);
+            let negated = not(conjTree);
             for (const step of steps) {
                 negated = step.transform(negated, ctx);
             }
@@ -425,7 +607,7 @@ export function setupApp(
             }
             refreshSymtab();
 
-            verdictEl.textContent = `Refuting: axioms ∧ ¬(${printPlainSentence(conjecture.tree, ex.symbolTable)}) — searching for □ …`;
+            verdictEl.textContent = `Refuting: axioms ∧ ¬(${printPlainSentence(conjTree, workingSt)}) — searching for □ …`;
             for (let i = 0; i < numbered.length; i++) {
                 addClauseRow(clausesEl, i + 1, numbered[i].label, clauseToString(numbered[i].clause));
                 await sleep(90 * durationMult());
@@ -454,6 +636,11 @@ export function setupApp(
     playBtn.addEventListener('click', () => { void playAll(); });
     resetBtn.addEventListener('click', reset);
     proveBtn.addEventListener('click', () => { void doProve(); });
+    applyBtn.addEventListener('click', applyEditor);
+    editBtn.addEventListener('click', editCurrentExample);
+    conjTypedInput.addEventListener('keydown', (ev) => {
+        if (ev.key === 'Enter') void doProve();
+    });
 
-    selectExample(0);
+    loadExample(0);
 }


### PR DESCRIPTION
Adds a **Custom ✎** tab with a formula editor so users can explore their own theories end-to-end: write axioms, watch them animate through the clausal-form pipeline, and prove their own conjectures.

- **Parser** (`src/notation/parser.ts`): recursive-descent FOL grammar that accepts exactly what the app prints — every built-in example round-trips via **✎ edit in editor** with identical rendered axioms — plus ASCII aliases (`forall`, `exists`, `~`, `&`, `|`, `->`, `<-`, `<->`, `*`). Symbol roles/arities inferred from use with conflict errors; `u`–`z` and quantifier-bound names are variables (alpha-renamed at parse time).
- **Editor UI**: axioms + conjectures one per line (`label:` prefixes, `#` comments), symbol toolbar, line-numbered errors, starter family-relations theory.
- **Typed conjectures everywhere**: an input next to the conjecture menu parses against the current example's symbols (new symbols registered on the fly) — e.g. type `forall x. GOD(x) -> ~MAN(x)` on Socrates and watch the negation skolemize and refute.

Verified headlessly (27 checks, zero console errors): starter proofs, ASCII-edited theory proofs, parse-error paths, all four built-ins round-tripping and re-proving, typed conjectures incl. skolemized universals and honest failure on a new constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)