### PR TITLE
Add wolf, goat & cabbage river-crossing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Four example theories are included, each chosen so a different pipeline step get
 - **Peano arithmetic** — the classic axioms, plus a `¬∃x.[NAT(x)]∧[succ(x)=0]` row that double-flips under De Morgan.
 - **Group theory** — closure, associativity, identity, inverses; the "nontrivial" axiom `¬∀x.x=e` flips its quantifier into `∃x.¬(x=e)`.
 - **Socrates & the gods** — syllogisms where `¬∃x.¬MORTAL(x)` cancels a hidden double negation into `∀x.MORTAL(x)`.
+- **Wolf, goat & cabbage** — the classic river crossing as pure logic: only safe crossings are axioms, and proving `REACH(R,R,R,R)` yields an 8-step refutation that *is* the farmer's ferry plan.
 - **Safety interlock** — propositional rules whose biconditionals mint genuine `¬¬` pairs, giving the `¬¬` cancel step real work.
 
 ### Properties of vitefolts

--- a/src/examples.ts
+++ b/src/examples.ts
@@ -123,6 +123,48 @@ function buildInterlock(): AxiomSet {
     return { truthBag, axioms, conjectures };
 }
 
+function buildRiverCrossing(): AxiomSet {
+    const REACH_id = n2SI(0, 0);
+    const L_id = n2SI(0, 1);
+    const R_id = n2SI(0, 2);
+
+    let truthBag = new TruthBag();
+    truthBag = truthBag.add_predicate(REACH_id, 'REACH', 4, false);
+    truthBag = truthBag.add_function(L_id, 'L', 0, false);
+    truthBag = truthBag.add_function(R_id, 'R', 0, false);
+
+    const L = fn(L_id);
+    const R = fn(R_id);
+    // REACH(farmer, wolf, goat, cabbage) — which bank each is on.
+    const at = (f: SentenceTreeNode, w: SentenceTreeNode, g: SentenceTreeNode, c: SentenceTreeNode) =>
+        pred(REACH_id, f, w, g, c);
+
+    // Only crossings between SAFE states are axioms: the goat is never left
+    // with the wolf or the cabbage without the farmer.
+    const axioms: Axiom[] = [
+        { tree: at(L, L, L, L), note: 'start' },
+        { tree: implies(at(L, L, L, L), at(R, L, R, L)), note: 'take goat →' },
+        { tree: implies(at(R, L, R, L), at(L, L, R, L)), note: '← row back' },
+        { tree: implies(at(L, L, R, L), at(R, R, R, L)), note: 'take wolf →' },
+        { tree: implies(at(R, R, R, L), at(L, R, L, L)), note: '← bring goat back' },
+        { tree: implies(at(L, R, L, L), at(R, R, L, R)), note: 'take cabbage →' },
+        { tree: implies(at(R, R, L, R), at(L, R, L, R)), note: '← row back' },
+        { tree: implies(at(L, R, L, R), at(R, R, R, R)), note: 'take goat →' },
+        { tree: implies(at(L, L, R, L), at(R, L, R, R)), note: 'or: take cabbage →' },
+        { tree: implies(at(R, L, R, R), at(L, L, L, R)), note: '← bring goat back' },
+        { tree: implies(at(L, L, L, R), at(R, R, L, R)), note: 'take wolf →' },
+    ];
+    const conjectures: Conjecture[] = [
+        { tree: at(R, R, R, R), remark: 'the 8-step proof is the ferry plan' },
+        { tree: at(L, R, L, R), remark: 'wolf and cabbage across, goat home' },
+        { tree: at(R, L, L, R), remark: 'wolf would eat the goat — unreachable' },
+    ];
+    for (const a of axioms) {
+        truthBag = truthBag.add_sentence(a.tree, a.note);
+    }
+    return { truthBag, axioms, conjectures };
+}
+
 export const EXAMPLES: ExampleDef[] = [
     {
         name: 'Peano arithmetic',
@@ -138,6 +180,11 @@ export const EXAMPLES: ExampleDef[] = [
         name: 'Socrates & the gods',
         hint: 'Aristotle with a twist: "no god is a man" double-flips (∃→∀, ∧→∨), and "nothing escapes death" cancels a hidden ¬¬ into ∀x.MORTAL(x).',
         build: buildSocrates,
+    },
+    {
+        name: 'Wolf, goat & cabbage',
+        hint: 'The classic river crossing as pure logic: REACH(farmer, wolf, goat, cabbage) says who is on which bank (L or R), and only safe crossings are axioms — the goat is never left with the wolf or the cabbage. Prove REACH(R,R,R,R) and the refutation, read top to bottom, is the farmer\'s ferry plan.',
+        build: buildRiverCrossing,
     },
     {
         name: 'Safety interlock',

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -698,7 +698,7 @@ export function setupApp(
                 await sleep(90 * durationMult());
             }
 
-            const proof = prove(numbered.map((n) => n.clause), sosIndices, proverEnv);
+            const proof = prove(numbered.map((n) => n.clause), sosIndices, proverEnv, { maxDepth: 12 });
             if (proof === null) {
                 verdictEl.textContent = '✗ No refutation found within the search limits — the conjecture does not follow from these axioms (or needs a deeper proof).';
                 verdictEl.className = 'verdict fail';


### PR DESCRIPTION
The classic puzzle as pure logic: `REACH(farmer, wolf, goat, cabbage)` records banks (L/R), and only crossings between safe states are axioms — the goat is never left alone with the wolf or the cabbage. Both the goat-first and cabbage-first solution branches are encoded.

Proving `REACH(R,R,R,R)` derives □ in exactly 8 resolutions, and the animated proof read top to bottom **is the ferry plan**:

take goat → row back → take wolf → bring goat back → take cabbage → row back → take goat → done.

Also: an intermediate-state conjecture, an unreachable unsafe state (`REACH(R,L,L,R)`) that fails honestly, and prover depth raised to 12 for exploration headroom.

Verified headlessly: 8-step plan proof, intermediate proof, unreachable failure, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)