### PR TITLE
Add prominent GitHub link in the demo header

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -37,6 +37,34 @@ body {
     padding: 2rem 1.5rem 4rem;
 }
 
+header {
+    position: relative;
+}
+
+.gh-link {
+    position: absolute;
+    top: 0.2rem;
+    right: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.4rem 0.9rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--panel);
+    color: var(--ink);
+    font-size: 0.88rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: border-color 0.2s ease, color 0.2s ease, transform 0.1s ease;
+}
+
+.gh-link:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+    transform: translateY(-1px);
+}
+
 header h1 {
     margin: 0;
     font-size: 2.4rem;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -178,6 +178,11 @@ export function setupApp(
 ): void {
     root.innerHTML = `
         <header>
+            <a class="gh-link" href="https://github.com/rudi-cilibrasi/vitefolts" target="_blank" rel="noopener"
+                title="vitefolts on GitHub">
+                <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+                <span>GitHub</span>
+            </a>
             <h1>vitefolts</h1>
             <p class="tagline">A first-order logic engine — watch axiom sets morph into clausal form,
             then watch a refutation proof unfold. Surviving symbols glide along splines; conversions like


### PR DESCRIPTION
A pill badge with the GitHub mark in the top-right corner linking back to the repo (the footer link stays too). Verified rendering headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)