### PR TITLE
Add GoatCounter analytics snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,5 +23,7 @@
   <body>
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
+    <script data-goatcounter="https://cilibrar.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Adds the GoatCounter tracking script to `index.html` just before `</body>`, pointing at https://cilibrar.goatcounter.com/count. Verified the tag passes through `vite build` into `dist/index.html` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)