### PR TITLE
Prove 1 + 1 = 2: add the successor-addition axiom (closes #15)

### DIFF
--- a/src/axioms.test.ts
+++ b/src/axioms.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { buildPeanoAxioms } from './axioms';
+import { proveTrees } from './notation/engine';
+
+describe('Peano example (issue #15)', () => {
+    it('proves its 1 + 1 = 2 conjecture from the shipped axioms', () => {
+        const { axioms, conjectures } = buildPeanoAxioms();
+        const onePlusOne = conjectures[0]; // succ(0) + succ(0) = succ(succ(0))
+        const result = proveTrees(
+            axioms.map((a) => a.tree),
+            onePlusOne.tree,
+            { maxDepth: 12 },
+        );
+        expect(result.proved).toBe(true);
+    });
+
+    it('still proves NAT(succ(0))', () => {
+        const { axioms, conjectures } = buildPeanoAxioms();
+        const natSuccZero = conjectures[conjectures.length - 1];
+        const result = proveTrees(axioms.map((a) => a.tree), natSuccZero.tree, { maxDepth: 10 });
+        expect(result.proved).toBe(true);
+    });
+});

--- a/src/axioms.ts
+++ b/src/axioms.ts
@@ -39,6 +39,7 @@ export function buildPeanoAxioms(): AxiomSet {
     truthBag = truthBag.add_function(succ, "succ", 1, false);
     truthBag = truthBag.add_function(PLUS, "+", 2, true);
     truthBag = truthBag.add_definition("1", succ_zero);
+    truthBag = truthBag.add_definition("2", S3(OperationType.FUNCTIONCALL, List([succ_zero]), List([succ])));
 
     const x = S3(OperationType.VARIABLE_INSTANCE, List(), List([x_id]));
     const y = S3(OperationType.VARIABLE_INSTANCE, List(), List([y_id]));
@@ -120,7 +121,22 @@ export function buildPeanoAxioms(): AxiomSet {
     const forall_x__x_plus_zero_eq_x = S3(OperationType.FORALL, List([x_plus_zero_eq_x]), List([x_id]));
     addAxiom(forall_x__x_plus_zero_eq_x, "additive identity");
 
+    // x + succ(y) = succ(x + y) — the recursion that makes addition compute.
+    // Without it, x + 0 = x alone cannot reach 1 + 1 = 2 (issue #15).
+    const x_plus_y = S3(OperationType.FUNCTIONCALL, List([x, y]), List([PLUS]));
+    const x_plus_succ_y = S3(OperationType.FUNCTIONCALL, List([x, succ_y]), List([PLUS]));
+    const succ_of_x_plus_y = S3(OperationType.FUNCTIONCALL, List([x_plus_y]), List([succ]));
+    const addition_recursion = S3(OperationType.EQUALS, List([x_plus_succ_y, succ_of_x_plus_y]), List([]));
+    const forall_xy__addition_recursion = S3(OperationType.FORALL, List([addition_recursion]), List([x_id, y_id]));
+    addAxiom(forall_xy__addition_recursion, "addition recursion");
+
+    // 1 + 1 = 2, i.e. succ(0) + succ(0) = succ(succ(0)).
+    const two = S3(OperationType.FUNCTIONCALL, List([succ_zero]), List([succ]));
+    const one_plus_one = S3(OperationType.FUNCTIONCALL, List([succ_zero, succ_zero]), List([PLUS]));
+    const one_plus_one_eq_two = S3(OperationType.EQUALS, List([one_plus_one, two]), List([]));
+
     const conjectures: Conjecture[] = [
+        { tree: one_plus_one_eq_two, remark: '1 + 1 = 2 — needs the addition-recursion axiom' },
         { tree: exists([x_id], pred(nat_id, fn(succ, varr(x_id)))) },
         { tree: pred(nat_id, fn(PLUS, zero, zero)), remark: 'needs paramodulation' },
         { tree: pred(nat_id, succ_zero), remark: '1 is defined as succ(0)' },

--- a/src/notation/engine.ts
+++ b/src/notation/engine.ts
@@ -99,21 +99,34 @@ export function proveConjecture(
     conjecture: string,
     options?: ProveOptions,
 ): TheoryResult {
+    // One shared registry so a predicate or function of the same name is the
+    // same symbol across every sentence — without it, complementary literals
+    // from different sentences would never unify.
     const registry = new Registry();
+    const axiomTrees = axioms.map((axiom) => parseSentence(axiom, registry));
+    const conjectureTree = parseSentence(conjecture, registry);
+    return proveTrees(axiomTrees, conjectureTree, options);
+}
+
+// Prove a conjecture given axioms as already-built sentence trees (e.g. from
+// the programmatic example builders). Refutes axioms ∧ ¬conjecture.
+export function proveTrees(
+    axiomTrees: SentenceTreeNode[],
+    conjectureTree: SentenceTreeNode,
+    options?: ProveOptions,
+): TheoryResult {
     const ctx = makeStepContext();
     const env = makeProverEnv();
 
     const clauses: Clause[] = [];
-    for (const axiom of axioms) {
-        const parsed = parseSentence(axiom, registry);
-        for (const clause of sentenceToClauses(parsed, ctx)) {
+    for (const tree of axiomTrees) {
+        for (const clause of sentenceToClauses(tree, ctx)) {
             clauses.push(clause);
         }
     }
 
-    const negated = not(parseSentence(conjecture, registry));
     const sosIndices: number[] = [];
-    for (const clause of sentenceToClauses(negated, ctx)) {
+    for (const clause of sentenceToClauses(not(conjectureTree), ctx)) {
         sosIndices.push(clauses.length);
         clauses.push(clause);
     }


### PR DESCRIPTION
## What & why

Closes #15. `1 + 1 = 2` was **not** provable from the Peano example — not an engine limitation, a **missing axiom**. The example had additive identity `∀x. x + 0 = x` but no recursive successor-addition axiom, so `succ(0) + succ(0) = succ(succ(0))` did not follow.

This adds:
- **`∀x,y. x + succ(y) = succ(x + y)`** — the recursion that makes addition compute.
- a definition `2 = succ(succ(0))`, and **`1 + 1 = 2` as the lead conjecture**, so the flagship demo proves it directly (a few paramodulation steps against the recursion + identity axioms, closing on reflexivity).

Engine/testing:
- `proveTrees()` added to the headless facade — prove from programmatic sentence trees, not only text.
- Regression test refutes `axioms ∧ ¬(1+1=2)` from the shipped `buildPeanoAxioms()`, and asserts the existing `NAT(succ(0))` conjecture still proves.

Verified locally: typecheck, build, and all 26 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)