### PR TITLE
fix(prover): per-depth attempt budget + configurable clause caps

### DIFF
--- a/src/notation/engine.test.ts
+++ b/src/notation/engine.test.ts
@@ -80,3 +80,20 @@ describe('non-theorems the prover must reject (bounded search)', () => {
         expect(proveConjecture(PEANO_ARITH, 'succ(0) + 0 = 0', { maxDepth: 8 }).proved).toBe(false);
     });
 });
+
+describe('deep search under a per-depth attempt budget', () => {
+    // A long modus-ponens chain P0, P0→P1, …, P9→P10 ⊢ P10 needs an 11-step
+    // refutation. With the attempt budget shared across iterative-deepening
+    // depths, shallow re-search exhausts a small budget before the search
+    // reaches depth 11; resetting per depth finds it.
+    // At maxAttempts=60 a single shared budget is exhausted by shallow
+    // re-search and never reaches the depth-11 refutation (verified: it fails
+    // with the shared budget, succeeds once reset per depth).
+    const CHAIN = 10;
+    const axioms = ['P0', ...Array.from({ length: CHAIN }, (_, i) => `P${i} -> P${i + 1}`)];
+
+    it('proves the end of a long chain within a tight per-depth budget', () => {
+        const result = proveConjecture(axioms, `P${CHAIN}`, { maxDepth: 14, maxAttempts: 60 });
+        expect(result.proved).toBe(true);
+    });
+});

--- a/src/notation/resolution.ts
+++ b/src/notation/resolution.ts
@@ -132,15 +132,20 @@ interface Candidate {
     step: ProofStep;
 }
 
-const MAX_LITERALS = 6;
-const MAX_CLAUSE_SIZE = 60;
+const DEFAULT_MAX_LITERALS = 6;
+const DEFAULT_MAX_CLAUSE_SIZE = 60;
 
-function candidatesWith(center: Clause, side: Clause, sideRef: SideRef, env: ProverEnv): Candidate[] {
+interface ClauseLimits {
+    maxLiterals: number;
+    maxClauseSize: number;
+}
+
+function candidatesWith(center: Clause, side: Clause, sideRef: SideRef, env: ProverEnv, limits: ClauseLimits): Candidate[] {
     const out: Candidate[] = [];
     const renamed = renameClause(side, env);
     const push = (kind: ProofStep['kind'], subst: Subst, resolvent: Clause, withSide: boolean) => {
-        if (resolvent.literals.length > MAX_LITERALS) return;
-        if (clauseSize(resolvent) > MAX_CLAUSE_SIZE) return;
+        if (resolvent.literals.length > limits.maxLiterals) return;
+        if (clauseSize(resolvent) > limits.maxClauseSize) return;
         if (isTautology(resolvent)) return;
         out.push({
             step: {
@@ -227,12 +232,23 @@ function factorCandidates(center: Clause): Candidate[] {
 
 export interface ProveOptions {
     maxDepth?: number;
+    // Attempt budget PER iterative-deepening depth (reset at each depth), not
+    // a single budget shared across depths — otherwise shallow re-search burns
+    // it and deep proofs become unreachable.
     maxAttempts?: number;
+    // Hard caps that prune oversized resolvents during search. Raising them
+    // lets larger clauses through at the cost of a bigger search space.
+    maxLiterals?: number;
+    maxClauseSize?: number;
 }
 
 export function prove(inputs: Clause[], sosIndices: number[], env: ProverEnv, options?: ProveOptions): Proof | null {
     const maxDepth = options?.maxDepth ?? 8;
     const budget = { attempts: 0, max: options?.maxAttempts ?? 20000 };
+    const limits: ClauseLimits = {
+        maxLiterals: options?.maxLiterals ?? DEFAULT_MAX_LITERALS,
+        maxClauseSize: options?.maxClauseSize ?? DEFAULT_MAX_CLAUSE_SIZE,
+    };
 
     const dfs = (
         center: Clause,
@@ -246,10 +262,10 @@ export function prove(inputs: Clause[], sosIndices: number[], env: ProverEnv, op
 
         const candidates: Candidate[] = [];
         inputs.forEach((clause, index) => {
-            candidates.push(...candidatesWith(center, clause, { kind: 'input', index }, env));
+            candidates.push(...candidatesWith(center, clause, { kind: 'input', index }, env, limits));
         });
         derived.forEach((clause, index) => {
-            candidates.push(...candidatesWith(center, clause, { kind: 'derived', index }, env));
+            candidates.push(...candidatesWith(center, clause, { kind: 'derived', index }, env, limits));
         });
         candidates.push(...factorCandidates(center));
         candidates.sort((a, b) => a.step.resolvent.literals.length - b.step.resolvent.literals.length
@@ -271,6 +287,10 @@ export function prove(inputs: Clause[], sosIndices: number[], env: ProverEnv, op
     };
 
     for (let depth = 1; depth <= maxDepth; depth++) {
+        // Fresh budget for each depth: iterative deepening re-explores the
+        // shallow layers every pass, so a single shared budget would be spent
+        // there before the search ever reaches the depth a long proof needs.
+        budget.attempts = 0;
         for (const start of sosIndices) {
             const center = inputs[start];
             const steps = dfs(center, [], new Set([clauseKey(center)]), depth);


### PR DESCRIPTION
## What & why

Two completeness fixes in `resolution.ts`, both correctness-relevant:

**1. Reset the attempt budget per iterative-deepening depth.** `prove()` created its `budget` once and never reset it across the `for depth = 1..maxDepth` loop. Since IDDFS re-explores the shallow layers on every pass, a shared budget is spent there before the search ever reaches the depth a long proof needs — so deep proofs silently return "not found."

Verified with a depth-11 modus-ponens chain (`P0, P0→P1, …, P9→P10 ⊢ P10`): under the shared budget it **fails** at `maxAttempts` 40 and 60 and only succeeds at ≥100; reset per depth, it succeeds at 30. New regression test pins the distinguishing case at 60.

**2. Make the clause-pruning caps configurable.** `MAX_LITERALS = 6` and `MAX_CLAUSE_SIZE = 60` were module constants that silently dropped candidates — a theorem whose proof genuinely needs a 7-literal clause became a false negative reported as "does not follow." They're now `maxLiterals` / `maxClauseSize` on `ProveOptions`, defaulting to the same values.

All 27 tests green; typecheck and build clean. No app-visible behavior change at default options.

## Follow-up (separate PR)
Distinguish "not a theorem" from "search gave up (budget/depth/caps)" in `prove()`'s result and surface it in the UI verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)