### PR TITLE
feat(examples): Ancestry theory — a Skolem-function showcase

### DIFF
--- a/src/examples.test.ts
+++ b/src/examples.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { EXAMPLES } from './examples';
+import { proveTrees } from './notation/engine';
+
+describe('Ancestry example (Skolem-function showcase)', () => {
+    const def = EXAMPLES.find((e) => e.name === 'Ancestry');
+
+    it('is registered', () => {
+        expect(def).toBeDefined();
+    });
+
+    it('proves everyone has an ancestor (closes on the Skolem parent)', () => {
+        const { axioms, conjectures } = def!.build();
+        const result = proveTrees(axioms.map((a) => a.tree), conjectures[0].tree, { maxDepth: 10 });
+        expect(result.proved).toBe(true);
+    });
+
+    it('does not prove someone has no parent (contradicts an axiom)', () => {
+        const { axioms, conjectures } = def!.build();
+        const result = proveTrees(axioms.map((a) => a.tree), conjectures[1].tree, { maxDepth: 6, maxAttempts: 5000 });
+        expect(result.proved).toBe(false);
+    });
+});

--- a/src/examples.ts
+++ b/src/examples.ts
@@ -165,6 +165,41 @@ function buildRiverCrossing(): AxiomSet {
     return { truthBag, axioms, conjectures };
 }
 
+function buildAncestry(): AxiomSet {
+    const PARENT_id = n2SI(0, 0);
+    const ANC_id = n2SI(0, 1);
+    const x_id = n2SI(1, 0);
+    const y_id = n2SI(1, 1);
+    const z_id = n2SI(1, 2);
+
+    let truthBag = new TruthBag();
+    truthBag = truthBag.add_predicate(PARENT_id, 'PARENT', 2, false);
+    truthBag = truthBag.add_predicate(ANC_id, 'ANC', 2, false);
+
+    const x = varr(x_id);
+    const y = varr(y_id);
+    const z = varr(z_id);
+    const PARENT = (a: SentenceTreeNode, b: SentenceTreeNode) => pred(PARENT_id, a, b);
+    const ANC = (a: SentenceTreeNode, b: SentenceTreeNode) => pred(ANC_id, a, b);
+
+    const axioms: Axiom[] = [
+        // ∀x ∃y. PARENT(y, x) — the ∃y under a ∀x Skolemizes to a genuine
+        // unary function σ(x), the one example where a Skolem *function*
+        // (not just a constant) appears.
+        { tree: forall([x_id], exists([y_id], PARENT(y, x))), note: 'everyone has a parent' },
+        { tree: forall([x_id, y_id], implies(PARENT(x, y), ANC(x, y))), note: 'a parent is an ancestor' },
+        { tree: forall([x_id, y_id, z_id], implies(and(ANC(x, y), ANC(y, z)), ANC(x, z))), note: 'ancestry is transitive' },
+    ];
+    const conjectures: Conjecture[] = [
+        { tree: forall([x_id], exists([z_id], ANC(z, x))), remark: 'everyone has an ancestor — closes on the Skolem parent σ(x)' },
+        { tree: exists([x_id], forall([z_id], not(PARENT(z, x)))), remark: 'someone with no parent — not entailed, watch the search fail' },
+    ];
+    for (const a of axioms) {
+        truthBag = truthBag.add_sentence(a.tree, a.note);
+    }
+    return { truthBag, axioms, conjectures };
+}
+
 export const EXAMPLES: ExampleDef[] = [
     {
         name: 'Peano arithmetic',
@@ -190,5 +225,10 @@ export const EXAMPLES: ExampleDef[] = [
         name: 'Safety interlock',
         hint: 'Propositional machine-safety rules. The biconditionals mint genuine ¬¬ pairs — the only example where the ¬¬ cancel step has real work to do.',
         build: buildInterlock,
+    },
+    {
+        name: 'Ancestry',
+        hint: 'Everyone has a parent (∀x∃y), a parent is an ancestor, and ancestry is transitive. The ∃ under the ∀ Skolemizes to a real unary function σ(x) — the only example with a Skolem function rather than a constant. Prove everyone has an ancestor; the proof closes on σ of the negated-conjecture Skolem constant.',
+        build: buildAncestry,
     },
 ];


### PR DESCRIPTION
## What & why

Adds a sixth example theory. Every current example Skolemizes its `∃` to a **constant**, so students never see a Skolem *function*. **Ancestry** fills that gap:

- `∀x ∃y. PARENT(y, x)` — everyone has a parent → the `∃y` under the `∀x` Skolemizes to a genuine **unary function σ(x)**.
- `∀x,y. PARENT(x,y) → ANC(x,y)` and transitivity of `ANC`.

Conjectures:
- **Everyone has an ancestor** (`∀x ∃z. ANC(z,x)`) — proves; the refutation closes on `σ` applied to the negated-conjecture's Skolem constant, so the derivation literally shows a Skolem function meeting a Skolem constant.
- **Someone has no parent** — contradicts the first axiom, so the search correctly fails (a "watch it fail" case).

## Tests
New `examples.test.ts` drives the shipped builder: asserts the ancestor conjecture proves and the no-parent conjecture does not. Full suite 33 green; typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)