### PR TITLE
feat(engine): unsat core — which axioms did the proof use?

### DIFF
--- a/src/notation/engine.ts
+++ b/src/notation/engine.ts
@@ -79,12 +79,21 @@ export function sentenceToClauses(sentence: SentenceTreeNode, ctx: StepContext):
     return extractClauses(toClausalForm(sentence, ctx));
 }
 
+// Where each input clause came from — so a proof can be traced back to the
+// axioms it actually used.
+export type ClauseSource =
+    | { kind: 'axiom'; index: number }
+    | { kind: 'conjecture' }
+    | { kind: 'reflexivity' };
+
 export interface TheoryResult {
     proved: boolean;
     proof: Proof | null;
     // Every input clause handed to the prover, axioms first then the negated
     // conjecture, in order — useful for rendering or debugging a run.
     clauses: Clause[];
+    // Provenance of each clause in `clauses`, same order.
+    sources: ClauseSource[];
     // Indices into `clauses` of the negated-conjecture clauses (the set of
     // support the search starts from).
     sosIndices: number[];
@@ -119,16 +128,19 @@ export function proveTrees(
     const env = makeProverEnv();
 
     const clauses: Clause[] = [];
-    for (const tree of axiomTrees) {
+    const sources: ClauseSource[] = [];
+    axiomTrees.forEach((tree, index) => {
         for (const clause of sentenceToClauses(tree, ctx)) {
             clauses.push(clause);
+            sources.push({ kind: 'axiom', index });
         }
-    }
+    });
 
     const sosIndices: number[] = [];
     for (const clause of sentenceToClauses(not(conjectureTree), ctx)) {
         sosIndices.push(clauses.length);
         clauses.push(clause);
+        sources.push({ kind: 'conjecture' });
     }
 
     // Paramodulation rewrites a goal down to t = t but needs a positive
@@ -138,10 +150,38 @@ export function proveTrees(
     if (clauses.some(clauseHasEquality)) {
         const reflVar = n2SI(1, 0);
         clauses.push({ literals: [{ positive: true, atom: eq(varr(reflVar), varr(reflVar)) }] });
+        sources.push({ kind: 'reflexivity' });
     }
 
     const proof = prove(clauses, sosIndices, env, options);
-    return { proved: proof !== null, proof, clauses, sosIndices };
+    return { proved: proof !== null, proof, clauses, sources, sosIndices };
+}
+
+// The input clauses (indices into TheoryResult.clauses) a proof actually used
+// — its unsat core. Linear resolution keeps every used input reachable as a
+// direct `input` side reference, plus the clause the chain starts from.
+export function proofInputIndices(proof: Proof): number[] {
+    const used = new Set<number>([proof.startIndex]);
+    for (const step of proof.steps) {
+        if (step.sideRef !== null && step.sideRef.kind === 'input') {
+            used.add(step.sideRef.index);
+        }
+    }
+    return [...used].sort((a, b) => a - b);
+}
+
+// The axiom indices (into the original axioms array) a proof relied on — the
+// answer to "which of my axioms did this actually need?".
+export function usedAxioms(result: TheoryResult): number[] {
+    if (result.proof === null) return [];
+    const axioms = new Set<number>();
+    for (const i of proofInputIndices(result.proof)) {
+        const source = result.sources[i];
+        if (source !== undefined && source.kind === 'axiom') {
+            axioms.add(source.index);
+        }
+    }
+    return [...axioms].sort((a, b) => a - b);
 }
 
 export { ParseError, Registry, parseSentence } from './parser';

--- a/src/notation/unsat-core.test.ts
+++ b/src/notation/unsat-core.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { proofInputIndices, proveConjecture, usedAxioms } from './engine';
+
+describe('unsat core: which axioms a proof used', () => {
+    const AX = [
+        'forall x. MAN(x) -> MORTAL(x)', // 0
+        'MAN(socrates)', // 1
+        'forall x. GOD(x) -> ~MORTAL(x)', // 2 — irrelevant to MORTAL(socrates)
+    ];
+
+    it('reports only the axioms the proof needs, not the irrelevant one', () => {
+        const result = proveConjecture(AX, 'MORTAL(socrates)');
+        expect(result.proved).toBe(true);
+        expect(usedAxioms(result)).toEqual([0, 1]);
+    });
+
+    it('the chain starts from a negated-conjecture clause', () => {
+        const result = proveConjecture(AX, 'MORTAL(socrates)');
+        const start = result.proof!.startIndex;
+        expect(result.sources[start]!.kind).toBe('conjecture');
+        expect(proofInputIndices(result.proof!)).toContain(start);
+    });
+
+    it('returns no axioms when nothing was proved', () => {
+        const result = proveConjecture(AX, 'GOD(socrates)', { maxDepth: 6 });
+        expect(result.proved).toBe(false);
+        expect(usedAxioms(result)).toEqual([]);
+    });
+});

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -6,6 +6,7 @@ import { eq, not, varr } from './notation/builders';
 import { Clause, StepContext, clauseHasEquality, extractClauses } from './notation/cnf';
 import { ParseError, Registry, parseSentence } from './notation/parser';
 import { Proof, ProverEnv, SideRef, prove } from './notation/resolution';
+import { proofInputIndices } from './notation/engine';
 import { n2SI, ScopedId } from './notation/scope';
 import { SentenceTreeNode } from './notation/sentence-tree-node';
 import { SymbolTable } from './notation/symbol-table';
@@ -701,7 +702,13 @@ export function setupApp(
                 verdictEl.className = 'verdict fail';
             } else {
                 await animateProof(numbered, proof);
-                verdictEl.textContent = `□ Empty clause derived in ${proof.steps.length} step${proof.steps.length === 1 ? '' : 's'} — contradiction. The conjecture is a theorem.`;
+                const usedLabels = Array.from(new Set(
+                    proofInputIndices(proof)
+                        .map((i) => numbered[i]?.label)
+                        .filter((l): l is string => l !== undefined && l !== '¬ conjecture' && l !== 'reflexivity'),
+                ));
+                const usedNote = usedLabels.length > 0 ? ` Axioms used: ${usedLabels.join(', ')}.` : '';
+                verdictEl.textContent = `□ Empty clause derived in ${proof.steps.length} step${proof.steps.length === 1 ? '' : 's'} — contradiction. The conjecture is a theorem.${usedNote}`;
                 verdictEl.className = 'verdict ok';
             }
         } catch (err) {


### PR DESCRIPTION
## What & why

A resolution proof often needs only a handful of a theory's axioms. This surfaces that "unsat core":

- `proofInputIndices(proof)` — the input clauses (by index) the proof used.
- `usedAxioms(result)` — the original axiom indices it relied on.
- `TheoryResult.sources` — provenance (`axiom` / `conjecture` / `reflexivity`) for every input clause.

Because the search is linear resolution, every used input is referenced directly as an `input` side-step, so the set is **exact**, not an over-approximation.

**Demo:** after `□` is derived, the verdict now lists the axioms actually used — e.g. proving Socrates' mortality reports "Axioms used: all men are mortal, socrates is a man" and omits the god axioms. For a large theory this shows students the *relevant* subset.

## Tests
Assert the Socrates core is exactly `[0, 1]` (not the irrelevant god axiom), that the chain starts from a negated-conjecture clause, and that an unproved conjecture yields no core. Full suite 36 green; typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)