### PR TITLE
chore(engine): standalone typed library build (toward #17)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,4 @@ jobs:
       - run: npm run typecheck
       - run: npm test
       - run: npm run build
+      - run: npm run build:lib

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-lib
 dist-ssr
 *.local
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ console.log(result.proved); // true
 
 Input syntax accepts ASCII aliases (`forall`, `exists`, `~`, `&`, `|`, `->`, `<-`, `<->`, and `*` for `·`). Names `u`–`z` are variables and other names are constants; a name in predicate position is a predicate, in term position a function.
 
+The engine (`src/notation/`) is self-contained — its only runtime dependency is `immutable` — and `npm run build:lib` emits it as an ESM bundle-consumable library with type declarations to `dist-lib/` (`dist-lib/engine.js`, `dist-lib/engine.d.ts`). This is the basis for extracting it as a standalone package (issue #17).
+
 ### Development
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "typecheck": "tsc -p tsconfig.test.json --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "build:lib": "tsc -p tsconfig.lib.json"
   },
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "outDir": "dist-lib",
+    "rootDir": "src/notation",
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true
+  },
+  "include": ["src/notation/**/*.ts"],
+  "exclude": ["src/notation/**/*.test.ts"]
+}


### PR DESCRIPTION
## What & why

Concrete groundwork for **#17** (extract the engine as a package). The `notation/*` engine has no DOM coupling and only depends on `immutable`, so it already emits as a clean library:

- `tsconfig.lib.json` + `npm run build:lib` → emits `dist-lib/` as ESM with `.d.ts` declarations (`engine.js` / `engine.d.ts` the entry point).
- Verified a bundled consumer imports `proveConjecture` / `usedAxioms` from `dist-lib/engine.js` and runs correctly.
- CI runs `build:lib`, so the engine stays extractable; `dist-lib/` is gitignored.
- README documents it.

**Deliberately not done here** (owner's call): renaming/un-privating the package, adding `exports`, and `npm publish`. Those are the packaging/release decisions; this PR proves the code is a real, typed, buildable library and keeps it that way.

No app behavior change; app build + all tests untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)