### PR TITLE
fix(prover): prune positive t = t tautologies during search

### DIFF
--- a/src/notation/engine.test.ts
+++ b/src/notation/engine.test.ts
@@ -64,6 +64,14 @@ describe('theorems the prover must find', () => {
         const result = proveConjecture(PEANO_ARITH, 'succ(0) + succ(0) = succ(succ(0))', { maxDepth: 10 });
         expect(result.proved).toBe(true);
     });
+
+    it('proves a = a via reflexivity, with no axioms', () => {
+        expect(proveConjecture([], 'a = a').proved).toBe(true);
+    });
+
+    it('proves symmetry of equality: c = b from b = c', () => {
+        expect(proveConjecture(['b = c'], 'c = b', { maxDepth: 6 }).proved).toBe(true);
+    });
 });
 
 describe('reverse implication (←) is eliminated, not crashed', () => {

--- a/src/notation/resolution.ts
+++ b/src/notation/resolution.ts
@@ -70,8 +70,15 @@ function substClause(clause: Clause, subst: Subst): Clause {
 }
 
 function isTautology(clause: Clause): boolean {
-    return clause.literals.some((l) =>
-        l.positive && clause.literals.some((m) => !m.positive && m.atom.equals(l.atom)));
+    return clause.literals.some((l) => {
+        // A positive t = t literal is always true, so the whole clause is.
+        if (l.positive && l.atom.operation === OperationType.EQUALS
+            && l.atom.children.get(0)!.equals(l.atom.children.get(1)!)) {
+            return true;
+        }
+        // Complementary literals p and ¬p on the same atom.
+        return l.positive && clause.literals.some((m) => !m.positive && m.atom.equals(l.atom));
+    });
 }
 
 function clauseSize(clause: Clause): number {


### PR DESCRIPTION
## What & why

`isTautology` (used to drop useless resolvents during search) only recognized complementary `p` / `¬p` literal pairs. It missed a **positive `t = t` literal**, which is always true — so a clause carrying one is a tautology and can never contribute to a refutation, yet it survived and consumed search budget. Standard redundancy elimination; completeness-preserving.

**Why it's safe for equality proofs:** the reflexivity axiom `x = x` we add for paramodulation is an *input* clause, never a pruned resolvent; and closing a `t ≠ t` goal produces the *empty* clause, not a positive `t = t`. Flagged by an adversarial engine audit.

## Tests
The equality suite (group-theory paramodulation, `1 + 1 = 2`) still passes, plus new cases: `a = a` proved via reflexivity from no axioms, and symmetry `c = b` from `b = c`. Full suite green; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)