### PR TITLE
chore(engine): emit a publishable folts-engine package (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,14 @@ console.log(result.proved); // true
 
 Input syntax accepts ASCII aliases (`forall`, `exists`, `~`, `&`, `|`, `->`, `<-`, `<->`, and `*` for `·`). Names `u`–`z` are variables and other names are constants; a name in predicate position is a predicate, in term position a function.
 
-The engine (`src/notation/`) is self-contained — its only runtime dependency is `immutable` — and `npm run build:lib` emits it as an ESM bundle-consumable library with type declarations to `dist-lib/` (`dist-lib/engine.js`, `dist-lib/engine.d.ts`). This is the basis for extracting it as a standalone package (issue #17).
+The engine (`src/notation/`) is self-contained — its only runtime dependency is `immutable` — and `npm run build:lib` emits it as a standalone, publishable ESM package to `dist-lib/`: type declarations (`engine.d.ts`), compiled modules (`engine.js` the entry), and a generated `dist-lib/package.json` declaring `folts-engine` with the right `exports`, `types`, and `immutable` dependency. To publish it (issue #17):
+
+```bash
+npm run build:lib
+cd dist-lib && npm publish   # requires `npm login`
+```
+
+The main repo package stays private; only `dist-lib/` is the published artifact.
 
 ### Development
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "build:lib": "tsc -p tsconfig.lib.json"
+    "build:lib": "tsc -p tsconfig.lib.json && node scripts/emit-lib-package.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/scripts/emit-lib-package.mjs
+++ b/scripts/emit-lib-package.mjs
@@ -1,0 +1,27 @@
+// Writes a standalone package.json into dist-lib/ so the emitted engine is a
+// self-contained, publishable npm package (issue #17): `cd dist-lib && npm publish`.
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const root = JSON.parse(readFileSync('package.json', 'utf8'));
+
+const pkg = {
+    name: 'folts-engine',
+    version: root.version,
+    description:
+        'First-order logic engine: parse, clausal-form conversion, and linear resolution with paramodulation.',
+    type: 'module',
+    main: './engine.js',
+    module: './engine.js',
+    types: './engine.d.ts',
+    exports: {
+        '.': { types: './engine.d.ts', import: './engine.js' },
+    },
+    files: ['*.js', '*.d.ts'],
+    dependencies: { immutable: root.dependencies.immutable },
+    license: 'MIT',
+    repository: { type: 'git', url: 'git+https://github.com/rudi-cilibrasi/vitefolts.git' },
+    keywords: ['first-order-logic', 'theorem-prover', 'resolution', 'paramodulation', 'fol'],
+};
+
+writeFileSync('dist-lib/package.json', JSON.stringify(pkg, null, 2) + '\n');
+console.log(`wrote dist-lib/package.json (${pkg.name}@${pkg.version})`);


### PR DESCRIPTION
## What & why

Advances #17 from "the engine builds as a library" to "the engine is a **publishable package**." `npm run build:lib` now also generates `dist-lib/package.json` (via `scripts/emit-lib-package.mjs`) declaring **`folts-engine`** — `exports`/`types`/`main` pointing at `engine.js`/`engine.d.ts`, `immutable` as the sole dependency, plus license/repo/keywords.

Verified: `cd dist-lib && npm pack --dry-run` produces a valid `folts-engine-0.0.0.tgz` (engine entry + all modules + declarations).

Publishing is now one command (README documents it):
```bash
npm run build:lib
cd dist-lib && npm publish   # requires npm login
```

The main repo package stays `private`; only `dist-lib/` is published. `dist-lib/` remains gitignored and CI keeps building it.

**Remaining for a full #17 close:** the actual `npm publish` (needs your npm auth) and, if you want, choosing a scoped name like `@folts/core`. Everything up to the publish button is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)