### PR TITLE
feat(ui): shareable + persistent custom theories (URL hash + localStorage)

### DIFF
--- a/src/permalink.test.ts
+++ b/src/permalink.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { decodeTheory, encodeTheory } from './permalink';
+
+describe('permalink encode/decode', () => {
+    it('round-trips a theory, including Unicode symbols and newlines', () => {
+        const ax = 'forall x. MAN(x) → MORTAL(x)\nMAN(socrates)';
+        const conj = 'MORTAL(socrates)\n∃x.GOD(x)  # not entailed';
+        const decoded = decodeTheory(encodeTheory(ax, conj));
+        expect(decoded).toEqual({ axioms: ax, conjectures: conj });
+    });
+
+    it('produces a URL-safe string (no +, /, or =)', () => {
+        const enc = encodeTheory('P(a) & Q(b) | R(c)', '∀x.∃y.LOVES(x,y)');
+        expect(enc).not.toMatch(/[+/=]/);
+    });
+
+    it('returns null on garbage input', () => {
+        expect(decodeTheory('not-valid-base64!!')).toBeNull();
+        expect(decodeTheory('')).toBeNull();
+    });
+
+    it('returns null when the payload lacks the expected shape', () => {
+        // Valid base64url of JSON that is not a {a,c} theory.
+        const enc = encodeTheory('x', 'y').slice(0, 4);
+        expect(decodeTheory(enc)).toBeNull();
+    });
+});

--- a/src/permalink.ts
+++ b/src/permalink.ts
@@ -1,0 +1,38 @@
+// Encode a custom theory (axioms + conjectures text) into a URL-safe string so
+// it can live in the location hash and localStorage — a shareable, reloadable
+// theory with no backend.
+
+interface Theory {
+    axioms: string;
+    conjectures: string;
+}
+
+function toBase64Url(json: string): string {
+    const bytes = new TextEncoder().encode(json);
+    let binary = '';
+    for (const b of bytes) binary += String.fromCharCode(b);
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function fromBase64Url(encoded: string): string {
+    const b64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+    const binary = atob(b64);
+    const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+}
+
+export function encodeTheory(axioms: string, conjectures: string): string {
+    return toBase64Url(JSON.stringify({ a: axioms, c: conjectures }));
+}
+
+export function decodeTheory(encoded: string): Theory | null {
+    try {
+        const obj = JSON.parse(fromBase64Url(encoded));
+        if (obj !== null && typeof obj.a === 'string' && typeof obj.c === 'string') {
+            return { axioms: obj.a, conjectures: obj.c };
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -8,6 +8,7 @@ import { ParseError, Registry, parseSentence } from './notation/parser';
 import { Proof, ProverEnv, SideRef, prove } from './notation/resolution';
 import { proofInputIndices } from './notation/engine';
 import { sentenceToLatex } from './notation/latex-printer';
+import { decodeTheory, encodeTheory } from './permalink';
 import { n2SI, ScopedId } from './notation/scope';
 import { SentenceTreeNode } from './notation/sentence-tree-node';
 import { SymbolTable } from './notation/symbol-table';
@@ -481,11 +482,40 @@ export function setupApp(
             .join('\n');
     }
 
+    const THEORY_STORAGE_KEY = 'folts.theory';
+
+    // Persist the current custom theory to the URL hash (shareable) and
+    // localStorage (survives reload), so a hand-built theory isn't lost.
+    function savePermalink(): void {
+        const encoded = encodeTheory(axInput.value, conjInput.value);
+        try {
+            history.replaceState(null, '', `#t=${encoded}`);
+        } catch { /* history unavailable — ignore */ }
+        try {
+            localStorage.setItem(THEORY_STORAGE_KEY, encoded);
+        } catch { /* storage blocked — ignore */ }
+    }
+
+    // A restorable custom theory from the URL hash first, then localStorage.
+    function storedTheory(): { axioms: string; conjectures: string } | null {
+        const hashMatch = /[#&]t=([^&]+)/.exec(window.location.hash);
+        if (hashMatch !== null) {
+            const fromHash = decodeTheory(hashMatch[1]);
+            if (fromHash !== null) return fromHash;
+        }
+        try {
+            const saved = localStorage.getItem(THEORY_STORAGE_KEY);
+            if (saved !== null) return decodeTheory(saved);
+        } catch { /* storage blocked — ignore */ }
+        return null;
+    }
+
     function applyEditor(): void {
         if (busy) return;
         try {
             allExamples[customIndex] = parseTheory(axInput.value, conjInput.value);
             editorErrEl.textContent = '';
+            savePermalink();
             loadExample(customIndex, true);
         } catch (err) {
             if (exampleIndex !== customIndex) {
@@ -755,5 +785,21 @@ export function setupApp(
         if (ev.key === 'Enter') void doProve();
     });
 
-    loadExample(0);
+    const restored = storedTheory();
+    let restoredOk = false;
+    if (restored !== null) {
+        try {
+            allExamples[customIndex] = parseTheory(restored.axioms, restored.conjectures);
+            axInput.value = restored.axioms;
+            conjInput.value = restored.conjectures;
+            savePermalink();
+            loadExample(customIndex, true);
+            restoredOk = true;
+        } catch {
+            // Corrupt or invalid stored theory — ignore it and show the default.
+        }
+    }
+    if (!restoredOk) {
+        loadExample(0);
+    }
 }


### PR DESCRIPTION
## What & why

Custom theories had **no persistence** — a hand-built theory was lost on reload, and there was no way to share one. Now:

- **Applying** the custom editor encodes its axioms + conjectures into the URL hash (`#t=…`, URL-safe base64) via `history.replaceState`, and mirrors it to `localStorage`. The URL is now a shareable permalink.
- **On load**, a stored theory is restored — hash first, then `localStorage` — and applied. It's only restored if it re-parses; a corrupt/invalid payload is ignored and the default example loads instead.

Encoding/decoding lives in `src/permalink.ts` (pure, Unicode-safe base64url) with tests for round-trip, URL-safety, and garbage rejection. Both write and restore paths are wrapped in try/catch so a blocked `history`/`localStorage` (e.g. private mode) degrades gracefully.

Full suite 56 green; lint + typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)