### PR TITLE
feat(audio): sonify formulas — hear the logic (addresses #48)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "folts",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "folts",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "immutable": "^4.3.6"
       },

--- a/src/audio/player.ts
+++ b/src/audio/player.ts
@@ -1,0 +1,76 @@
+import { NoteEvent } from './sonify';
+
+// Minimal Web Audio playback for a melody (issue #48). No external assets —
+// notes are synthesized with an oscillator. A single shared AudioContext is
+// created lazily on first user gesture (browsers require that).
+
+let ctx: AudioContext | null = null;
+
+function audioContext(): AudioContext | null {
+    if (ctx) return ctx;
+    const Ctor = window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (Ctor === undefined) return null; // Web Audio unavailable
+    ctx = new Ctor();
+    return ctx;
+}
+
+// A monotonically increasing token so a new play (or stop) supersedes any
+// in-flight sequence.
+let activeToken = 0;
+
+export function stopMelody(): void {
+    activeToken++;
+}
+
+export interface PlayOptions {
+    direction?: 'forward' | 'reverse';
+    noteMs?: number;
+    // Called as each event fires, with its index into the ORIGINAL events
+    // array (so callers can highlight the matching token regardless of direction).
+    onStep?: (index: number, event: NoteEvent) => void;
+    onDone?: () => void;
+}
+
+export function playMelody(events: NoteEvent[], opts: PlayOptions = {}): void {
+    const noteMs = opts.noteMs ?? 260;
+    const indices = events.map((_, i) => i);
+    const order = opts.direction === 'reverse' ? indices.reverse() : indices;
+
+    const ac = audioContext();
+    if (ac !== null && ac.state === 'suspended') void ac.resume();
+
+    const token = ++activeToken;
+    let step = 0;
+    const tick = (): void => {
+        if (token !== activeToken) return; // superseded or stopped
+        if (step >= order.length) {
+            opts.onDone?.();
+            return;
+        }
+        const idx = order[step];
+        const event = events[idx];
+        opts.onStep?.(idx, event);
+        if (event.kind === 'note' && ac !== null) {
+            playTone(ac, event.freq, noteMs);
+        }
+        step++;
+        setTimeout(tick, noteMs);
+    };
+    tick();
+}
+
+function playTone(ac: AudioContext, freq: number, ms: number): void {
+    const osc = ac.createOscillator();
+    const gain = ac.createGain();
+    osc.type = 'triangle';
+    osc.frequency.value = freq;
+    const t = ac.currentTime;
+    const dur = ms / 1000;
+    // Short attack/decay so notes are plucky, not droning.
+    gain.gain.setValueAtTime(0.0001, t);
+    gain.gain.exponentialRampToValueAtTime(0.18, t + 0.012);
+    gain.gain.exponentialRampToValueAtTime(0.0001, t + dur * 0.9);
+    osc.connect(gain).connect(ac.destination);
+    osc.start(t);
+    osc.stop(t + dur);
+}

--- a/src/audio/sonify.test.ts
+++ b/src/audio/sonify.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { Token, classify, melodyFrom, noteFor } from './sonify';
+
+const t = (tag: 'mi' | 'mo' | 'mn', text: string): Token => ({ tag, text });
+
+describe('token classification', () => {
+    it('classifies operators, variables, names, numbers, parens, and rests', () => {
+        expect(classify(t('mo', '∀'))).toBe('operator');
+        expect(classify(t('mo', '→'))).toBe('operator');
+        expect(classify(t('mi', 'x'))).toBe('variable');
+        expect(classify(t('mi', 'z'))).toBe('variable');
+        expect(classify(t('mi', 'MORTAL'))).toBe('name');
+        expect(classify(t('mi', 'socrates'))).toBe('name');
+        expect(classify(t('mn', '0'))).toBe('number');
+        expect(classify(t('mo', '('))).toBe('paren');
+        expect(classify(t('mo', ','))).toBe('rest');
+        expect(classify(t('mo', '.'))).toBe('rest');
+    });
+});
+
+describe('note mapping is consistent and structural', () => {
+    it('gives the same symbol the same note every time', () => {
+        expect(noteFor(t('mo', '∀'))).toEqual(noteFor(t('mo', '∀')));
+    });
+
+    it('gives distinct variables distinct pitches', () => {
+        const nx = noteFor(t('mi', 'x'));
+        const ny = noteFor(t('mi', 'y'));
+        expect(nx.kind).toBe('note');
+        expect(ny.kind).toBe('note');
+        if (nx.kind === 'note' && ny.kind === 'note') {
+            expect(nx.freq).not.toBe(ny.freq);
+        }
+    });
+
+    it('gives all predicate/function names one shared pitch', () => {
+        const a = noteFor(t('mi', 'MORTAL'));
+        const b = noteFor(t('mi', 'GOD'));
+        expect(a.kind).toBe('note');
+        expect(b.kind).toBe('note');
+        if (a.kind === 'note' && b.kind === 'note') {
+            expect(a.freq).toBe(b.freq); // same pitch; only the glyph differs
+        }
+    });
+
+    it('renders commas as rests', () => {
+        expect(noteFor(t('mo', ',')).kind).toBe('rest');
+    });
+
+    it('produces a melody event per token', () => {
+        const melody = melodyFrom([t('mo', '∀'), t('mi', 'x'), t('mo', '.'), t('mi', 'MAN'), t('mo', '→'), t('mi', 'MORTAL')]);
+        expect(melody).toHaveLength(6);
+        expect(melody.filter((e) => e.kind === 'note')).toHaveLength(5); // the dot is a rest
+    });
+});

--- a/src/audio/sonify.ts
+++ b/src/audio/sonify.ts
@@ -1,0 +1,96 @@
+// Pure formula → melody mapping (issue #48). A rendered formula is a flat run
+// of MathML tokens (<mi> names/variables, <mo> operators, <mn> numbers); this
+// turns each token into a note event. The mapping is fixed and consistent, so
+// the same symbol always sounds the same — letting a learner hear a formula
+// and hear how a clausal-form step changes it. Notes are chosen on the circle
+// of fifths so sequences come out harmonic rather than noisy.
+
+export type TokenTag = 'mi' | 'mo' | 'mn';
+export type Role = 'operator' | 'variable' | 'name' | 'number' | 'paren' | 'rest';
+
+export interface Token {
+    tag: TokenTag;
+    text: string;
+}
+
+export type NoteEvent =
+    | { kind: 'note'; role: Role; glyph: string; freq: number }
+    | { kind: 'rest'; role: Role; glyph: string };
+
+const C4 = 261.6255653; // middle C
+export function freqFromSemitones(semitones: number): number {
+    return C4 * Math.pow(2, semitones / 12);
+}
+
+// Circle-of-fifths semitone offsets — consonant when played in sequence.
+const OPERATOR_SEMITONES: Record<string, number> = {
+    '∀': 0, // C
+    '∃': 7, // G
+    '¬': 2, // D
+    '∧': 9, // A
+    '∨': 4, // E
+    '↔': 11, // B
+    '→': 6, // F#
+    '←': 1, // C#
+    '=': 5, // F
+    '·': 8, // G#
+    '+': 3, // D#
+    '-': 10, // A#
+    '/': 8,
+};
+
+// Each variable letter gets its own note, a register above the operators, so a
+// substitution x ↦ y is audible.
+const VARIABLE_SEMITONES: Record<string, number> = {
+    u: 19, v: 21, w: 23, x: 24, y: 26, z: 28,
+};
+
+// Predicates and functions share one steady lower note — the ear tracks
+// structure, not which name.
+const NAME_SEMITONES = -5; // G3
+const NUMBER_SEMITONES = -3; // A3
+const PAREN_SEMITONES = -12; // C3, a soft low blip
+
+function isVariableGlyph(text: string): boolean {
+    return /^[u-z]$/.test(text);
+}
+
+// Classify a single token by its tag and glyph.
+export function classify(token: Token): Role {
+    if (token.tag === 'mn') return 'number';
+    if (token.tag === 'mi') return isVariableGlyph(token.text) ? 'variable' : 'name';
+    // token.tag === 'mo'
+    const t = token.text;
+    if (t === ',') return 'rest'; // too frequent to be a pitch
+    if (t === '(' || t === ')' || t === '[' || t === ']') return 'paren';
+    if (t === '.') return 'rest'; // quantifier dot
+    return 'operator';
+}
+
+export function noteFor(token: Token): NoteEvent {
+    const role = classify(token);
+    const glyph = token.text;
+    switch (role) {
+        case 'rest':
+            return { kind: 'rest', role, glyph };
+        case 'operator': {
+            const semis = OPERATOR_SEMITONES[glyph];
+            // Unknown operator glyph: skip silently rather than guess a pitch.
+            if (semis === undefined) return { kind: 'rest', role: 'rest', glyph };
+            return { kind: 'note', role, glyph, freq: freqFromSemitones(semis) };
+        }
+        case 'variable':
+            return { kind: 'note', role, glyph, freq: freqFromSemitones(VARIABLE_SEMITONES[glyph]!) };
+        case 'name':
+            return { kind: 'note', role, glyph, freq: freqFromSemitones(NAME_SEMITONES) };
+        case 'number':
+            return { kind: 'note', role, glyph, freq: freqFromSemitones(NUMBER_SEMITONES) };
+        case 'paren':
+            return { kind: 'note', role, glyph, freq: freqFromSemitones(PAREN_SEMITONES) };
+    }
+}
+
+// Turn a token run into a melody. Same tokens → same melody, always.
+export function melodyFrom(tokens: Token[]): NoteEvent[] {
+    return tokens.map(noteFor);
+}

--- a/src/style.css
+++ b/src/style.css
@@ -682,3 +682,18 @@ footer a:hover {
         padding-top: 0;
     }
 }
+
+/* Sonification cursor: the symbol currently sounding (issue #48). */
+.sonify-on {
+    background: var(--accent-2);
+    color: var(--panel);
+    border-radius: 3px;
+    box-shadow: 0 0 0 2px var(--accent-2);
+    transition: background 60ms ease, box-shadow 60ms ease;
+}
+
+#btn-hear,
+#btn-hear-rev {
+    border-color: var(--accent-2);
+    color: var(--accent-2);
+}

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -8,6 +8,8 @@ import { ParseError, Registry, parseSentence } from './notation/parser';
 import { Proof, ProverEnv, SideRef, prove } from './notation/resolution';
 import { proofInputIndices } from './notation/engine';
 import { sentenceToLatex } from './notation/latex-printer';
+import { Token, melodyFrom } from './audio/sonify';
+import { playMelody, stopMelody } from './audio/player';
 import { decodeTheory, encodeTheory } from './permalink';
 import { n2SI, ScopedId } from './notation/scope';
 import { SentenceTreeNode } from './notation/sentence-tree-node';
@@ -218,6 +220,8 @@ export function setupApp(
             <button id="btn-step" type="button">Step ▸</button>
             <button id="btn-play" type="button">Play all ▸▸</button>
             <button id="btn-reset" type="button">↺ Reset</button>
+            <button id="btn-hear" type="button" title="Play the current formula as a melody — each symbol is a note (left → right)">♪ Hear ▶</button>
+            <button id="btn-hear-rev" type="button" title="Play the melody in reverse (right → left)">◀ ♪</button>
             <label class="speed-label">speed
                 <select id="speed">
                     <option value="2">slow</option>
@@ -265,6 +269,8 @@ export function setupApp(
     const stepBtn = root.querySelector<HTMLButtonElement>('#btn-step')!;
     const playBtn = root.querySelector<HTMLButtonElement>('#btn-play')!;
     const resetBtn = root.querySelector<HTMLButtonElement>('#btn-reset')!;
+    const hearBtn = root.querySelector<HTMLButtonElement>('#btn-hear')!;
+    const hearRevBtn = root.querySelector<HTMLButtonElement>('#btn-hear-rev')!;
     const speedSel = root.querySelector<HTMLSelectElement>('#speed')!;
     const conjectureSel = root.querySelector<HTMLSelectElement>('#conjecture')!;
     const conjTypedInput = root.querySelector<HTMLInputElement>('#conj-typed')!;
@@ -774,9 +780,38 @@ export function setupApp(
         }
     }
 
+    // Sonify the formula currently shown in the pipeline: each rendered MathML
+    // token becomes a note, swept left→right or right→left, highlighting the
+    // symbol as it sounds. Same symbol→note map every time, so a transform
+    // step is audible as a change in melody. (Issue #48.)
+    function hearFormula(direction: 'forward' | 'reverse'): void {
+        stopMelody();
+        const tokenEls = Array.from(pipelineEl.querySelectorAll<HTMLElement>('mi, mo, mn'));
+        for (const el of tokenEls) el.classList.remove('sonify-on');
+        if (tokenEls.length === 0) return;
+        const tokens: Token[] = tokenEls.map((el) => ({
+            tag: el.tagName.toLowerCase() as Token['tag'],
+            text: el.textContent ?? '',
+        }));
+        let prev: HTMLElement | null = null;
+        playMelody(melodyFrom(tokens), {
+            direction,
+            noteMs: 260 * durationMult(),
+            onStep: (idx) => {
+                if (prev !== null) prev.classList.remove('sonify-on');
+                const el = tokenEls[idx];
+                el.classList.add('sonify-on');
+                prev = el;
+            },
+            onDone: () => { if (prev !== null) prev.classList.remove('sonify-on'); },
+        });
+    }
+
     stepBtn.addEventListener('click', () => { void doStep(); });
     playBtn.addEventListener('click', () => { void playAll(); });
     resetBtn.addEventListener('click', reset);
+    hearBtn.addEventListener('click', () => hearFormula('forward'));
+    hearRevBtn.addEventListener('click', () => hearFormula('reverse'));
     proveBtn.addEventListener('click', () => { void doProve(); });
     latexBtn.addEventListener('click', () => { void copyLatex(); });
     applyBtn.addEventListener('click', applyEditor);


### PR DESCRIPTION
## What & why

MVP of #48 — multimodal learning. A **Hear ▶ / ◀** control sweeps the current pipeline formula, turning each rendered MathML token into a note and **highlighting the symbol as it sounds**. Because the symbol→note map is fixed and consistent, you can *hear* a formula — and hear how a clausal-form step changes the melody (step the pipeline, hit Hear again).

## Mapping (circle of fifths, so it's harmonic not noisy)
- Logical operators (`∀ ∃ ¬ ∧ ∨ → ↔ =`) → fixed distinct pitches.
- **Variables** (`u`–`z`) → each letter its own note, so a substitution `x ↦ y` is audible.
- **Predicates & functions** → one shared steady note (a function is a single note, per the issue).
- **Comma / quantifier dot** → rests; **parens** → a soft low blip.
- Both directions (left→right, right→left); tempo follows the speed selector.

## Implementation
- `src/audio/sonify.ts` — **pure** token→note mapping, unit-tested (classification, per-variable distinctness, shared name pitch, commas as rests).
- `src/audio/player.ts` — Web Audio oscillator playback, no external assets, guarded when audio is unavailable, with a per-step callback driving the highlight.
- Driven from the already-rendered MathML tokens (`mi/mo/mn`), so audio and the visual highlight share one source of truth.
- `audio/*` is app-only — **not** part of the `@folts/core` library.

68 tests green; build + lint + typecheck clean.

**Note:** I couldn't verify the actual sound in a browser from here — please give it a listen. Leaving #48 open for the fuller vision (a true sweeping vertical-line cursor, per-formula/per-clause controls, and selectable mappings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)