### PR TITLE
fix(audio): hear buttons as small squares flanking the formula

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -692,17 +692,32 @@ footer a:hover {
     transition: background 60ms ease, box-shadow 60ms ease;
 }
 
+.formula-row {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-width: 0;
+}
+
+.formula-row .glyphs {
+    flex: 1 1 auto;
+}
+
 .hear-btn {
+    flex: 0 0 auto;
+    width: 1.6rem;
+    height: 1.6rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border: 1px solid var(--border);
     background: var(--panel);
     color: var(--accent-2);
     border-radius: 4px;
-    padding: 0 0.4rem;
-    font-size: 0.8rem;
-    line-height: 1.4;
+    padding: 0;
+    font-size: 0.7rem;
+    line-height: 1;
     cursor: pointer;
-    align-self: center;
-    flex: 0 0 auto;
 }
 .hear-btn:hover {
     border-color: var(--accent-2);

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -401,10 +401,16 @@ export function setupApp(
             playRev.title = 'Hear this formula — right → left';
             playRev.addEventListener('click', () => hearContainer(glyphs, 'reverse'));
 
+            // ▶ [ formula ] ◀ share one flex cell so they sit at the ends of
+            // the (scrollable) formula rather than stretching the grid column.
+            const formulaRow = document.createElement('div');
+            formulaRow.className = 'formula-row';
+            formulaRow.appendChild(playFwd);
+            formulaRow.appendChild(glyphs);
+            formulaRow.appendChild(playRev);
+
             row.appendChild(label);
-            row.appendChild(playFwd);
-            row.appendChild(glyphs);
-            row.appendChild(playRev);
+            row.appendChild(formulaRow);
             sentencesEl.appendChild(row);
             rowGlyphEls.push(glyphs);
         }


### PR DESCRIPTION
## What & why

The ▶/◀ hear buttons rendered as **full-width bars stacked above/below each formula** (see the report). Cause: `.sentence-row` is a 2-column grid (`9.5rem 1fr`); the buttons and formula were appended as separate children and auto-placed into a 2×2 grid, so each button filled the content column.

Fix: wrap `▶ + formula + ◀` in one flex container that occupies the content column, and give `.hear-btn` a fixed **1.6rem square** size. Now the buttons are small squares at the left and right ends of the (still-scrollable) formula, on a single line.

Verified in a headless browser — buttons measure **26×26 px**, inline with the formula, no overlap:

![layout](/dev/null)

lint + typecheck + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)