### PR TITLE
feat(audio): consonant operator tuning + musical duality (∧/∨) and not-harmony

### DIFF
--- a/src/audio/sonify.test.ts
+++ b/src/audio/sonify.test.ts
@@ -47,6 +47,29 @@ describe('note mapping is consistent and structural', () => {
         expect(noteFor(t('mo', ',')).kind).toBe('rest');
     });
 
+    const freq = (glyph: string): number => {
+        const e = noteFor(t('mo', glyph));
+        if (e.kind !== 'note') throw new Error(`${glyph} is a rest`);
+        return e.freq;
+    };
+
+    it('sounds De Morgan / converse duals as inversions around the tonic', () => {
+        const tonic = freq('↔'); // the axis
+        // A dual pair mirrors around the tonic, so freq(a)·freq(b) = tonic².
+        for (const [a, b] of [['∀', '∃'], ['∧', '∨'], ['→', '←']]) {
+            expect(freq(a) * freq(b)).toBeCloseTo(tonic * tonic, 3);
+        }
+    });
+
+    it('makes ¬ harmonic with ∧, ∨, and ↔ (octave of the tonic axis)', () => {
+        // ¬ is the octave above ↔ (the reflection axis) — a perfect fourth
+        // above ∧ and a perfect fifth above ∨ (mod octave): all consonant.
+        expect(freq('¬')).toBeCloseTo(2 * freq('↔'), 3);
+        const ratioMod = (x: number, y: number) => { let r = x / y; while (r >= 2) r /= 2; return r; };
+        expect(ratioMod(freq('¬'), freq('∧'))).toBeCloseTo(4 / 3, 2); // perfect fourth
+        expect(ratioMod(freq('¬'), freq('∨'))).toBeCloseTo(3 / 2, 2); // perfect fifth
+    });
+
     it('produces a melody event per token', () => {
         const melody = melodyFrom([t('mo', '∀'), t('mi', 'x'), t('mo', '.'), t('mi', 'MAN'), t('mo', '→'), t('mi', 'MORTAL')]);
         expect(melody).toHaveLength(6);

--- a/src/audio/sonify.ts
+++ b/src/audio/sonify.ts
@@ -22,21 +22,28 @@ export function freqFromSemitones(semitones: number): number {
     return C4 * Math.pow(2, semitones / 12);
 }
 
-// Circle-of-fifths semitone offsets — consonant when played in sequence.
+// Operators use a consonant palette built around a tonic (C).
+//
+//  * Each De Morgan / converse dual pair is a pitch INVERSION around the tonic
+//    (∀/∃, ∧/∨, →/←): the dual is the reflection of its partner — the audible
+//    analogue of the animation flipping ∧ into ∨. A pair is +n / −n semitones,
+//    so their frequencies multiply to the tonic squared.
+//  * ↔ is self-dual and sits on the tonic (C4). ¬ — the operator that turns ∧
+//    into ∨ — sits on C5, the octave of that reflection axis: a perfect fourth
+//    above ∧ (G) and a perfect fifth+octave above ∨ (F). So ¬, ∧, ∨ (and ↔)
+//    form one consonant C–F–G family — negation harmonizes with and/or.
+const TONIC = 0; // C4
 const OPERATOR_SEMITONES: Record<string, number> = {
-    '∀': 0, // C
-    '∃': 7, // G
-    '¬': 2, // D
-    '∧': 9, // A
-    '∨': 4, // E
-    '↔': 11, // B
-    '→': 6, // F#
-    '←': 1, // C#
-    '=': 5, // F
-    '·': 8, // G#
-    '+': 3, // D#
-    '-': 10, // A#
-    '/': 8,
+    '↔': TONIC, // C4  — biconditional: self-dual, on the axis
+    '¬': 12, // C5  — negation: the complementer, an octave up
+    '=': 2, // D4  — equality: a symmetric relation
+    // De Morgan / converse dual pairs — mirror images around the tonic:
+    '∀': 4, '∃': -4, // E4 / A♭3  (∀ a third above, ∃ a third below)
+    '∧': 7, '∨': -7, // G4 / F3   (∧ a fifth above, ∨ a fifth below)
+    '→': 9, '←': -9, // A4 / E♭3  (converses)
+    // Term-level infix operators, kept consonant and out of the way:
+    '·': 5, '/': 5, // F4
+    '+': 14, '-': 16, // D5 / E5
 };
 
 // Each variable letter gets its own note, a register above the operators, so a

--- a/src/style.css
+++ b/src/style.css
@@ -692,17 +692,32 @@ footer a:hover {
     transition: background 60ms ease, box-shadow 60ms ease;
 }
 
+.formula-row {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-width: 0;
+}
+
+.formula-row .glyphs {
+    flex: 1 1 auto;
+}
+
 .hear-btn {
+    flex: 0 0 auto;
+    width: 1.6rem;
+    height: 1.6rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border: 1px solid var(--border);
     background: var(--panel);
     color: var(--accent-2);
     border-radius: 4px;
-    padding: 0 0.4rem;
-    font-size: 0.8rem;
-    line-height: 1.4;
+    padding: 0;
+    font-size: 0.7rem;
+    line-height: 1;
     cursor: pointer;
-    align-self: center;
-    flex: 0 0 auto;
 }
 .hear-btn:hover {
     border-color: var(--accent-2);

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -401,10 +401,16 @@ export function setupApp(
             playRev.title = 'Hear this formula — right → left';
             playRev.addEventListener('click', () => hearContainer(glyphs, 'reverse'));
 
+            // ▶ [ formula ] ◀ share one flex cell so they sit at the ends of
+            // the (scrollable) formula rather than stretching the grid column.
+            const formulaRow = document.createElement('div');
+            formulaRow.className = 'formula-row';
+            formulaRow.appendChild(playFwd);
+            formulaRow.appendChild(glyphs);
+            formulaRow.appendChild(playRev);
+
             row.appendChild(label);
-            row.appendChild(playFwd);
-            row.appendChild(glyphs);
-            row.appendChild(playRev);
+            row.appendChild(formulaRow);
             sentencesEl.appendChild(row);
             rowGlyphEls.push(glyphs);
         }


### PR DESCRIPTION
## What & why

Two requests: retune the operators to be consonant (they were the full chromatic scale), and **make complements audible** — plus **¬ harmonic with ∧/∨**.

- **Consonant palette** around a tonic (C) instead of all 12 chromatic semitones.
- **Duality as inversion:** each De Morgan / converse pair (`∀/∃`, `∧/∨`, `→/←`) is a pitch **inversion around the tonic** — the dual is the reflection of its partner, matching the animation flipping `∧` into `∨`. (For a pair at ±n semitones, `freq(a)·freq(b) = tonic²`.)
- **¬ harmonizes with and/or:** `↔` is self-dual on the tonic (C4); `¬` — the operator that turns `∧` into `∨` — sits on **C5, the octave of that reflection axis** — a perfect fourth above `∧`(G) and a perfect fifth above `∨`(F). So `↔·¬ (C)`, `∨ (F)`, `∧ (G)` form one consonant **C–F–G** family.

## Verified
- Unit tests lock the inversion (`freq(∧)·freq(∨) = freq(↔)²`) and ¬'s consonance (octave of ↔, P4 above ∧, P5 above ∨). 70 tests green.
- Live capture (Playwright + instrumented AudioContext): `ALARM ↔ ¬ GUARD` → `196, 261.6, 523.3, 196` Hz — `¬` (C5) is exactly an octave above `↔` (C4).

Variables (`u`–`z`), names, numbers, parens and rests are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)