### PR TITLE
fix(ui): widen layout to fill wide browsers + drop formula scrollbars

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -33,9 +33,9 @@ body {
 }
 
 #app {
-    max-width: 1080px;
+    max-width: 1800px;
     margin: 0 auto;
-    padding: 2rem 1.5rem 4rem;
+    padding: 2rem 2.5rem 4rem;
 }
 
 header {


### PR DESCRIPTION
## What & why

On wide screens the app was pinned to `max-width: 1080px`, leaving large empty margins, and long formulas (TRANSITIVITY) overflowed into a horizontal scrollbar because the content column was too narrow. Raise `#app` `max-width` to **1800px** (with slightly more side padding).

## Verified (headless, 1920 viewport)
- App content is now **~1800px** with **~60px** side margins (was ~460px).
- TRANSITIVITY glyph box: `scrollWidth == clientWidth` → **no scrollbar**, both at step 0 and in its long `→ out` expanded form.

Text paragraphs keep their own `ch`-based caps, so readability is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)