### PR TITLE
feat(ui): 'off' animation speed — instant step/back (redo of #54)

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -226,6 +226,7 @@ export function setupApp(
                     <option value="2">slow</option>
                     <option value="1" selected>normal</option>
                     <option value="0.5">fast</option>
+                    <option value="0">off</option>
                 </select>
             </label>
             <label class="speed-label">music
@@ -611,6 +612,16 @@ export function setupApp(
         return parseFloat(musicSel.value);
     }
 
+    // Render a formula step, animating over `duration` ms — or snapping
+    // instantly when animation is off (duration ≤ 0).
+    async function renderStep(el: HTMLElement, inner: string, duration: number): Promise<void> {
+        if (duration <= 0) {
+            renderMath(el, inner);
+            return;
+        }
+        await animateMath(el, inner, duration);
+    }
+
     async function doStep(): Promise<void> {
         if (busy || stepIndex >= steps.length) return;
         busy = true;
@@ -626,7 +637,7 @@ export function setupApp(
         const anyChange = newInners.some((t, k) => t !== oldInners[k]);
         if (anyChange) {
             const duration = BASE_DURATION_MS * durationMult();
-            await Promise.all(rowGlyphEls.map((el, k) => animateMath(el, newInners[k], duration)));
+            await Promise.all(rowGlyphEls.map((el, k) => renderStep(el, newInners[k], duration)));
         } else {
             statusEl.textContent = `${step.detail} — no change needed.`;
             await sleep(400 * durationMult());
@@ -652,7 +663,7 @@ export function setupApp(
         const anyChange = prevInners.some((t, k) => t !== curInners[k]);
         if (anyChange) {
             const duration = BASE_DURATION_MS * durationMult();
-            await Promise.all(rowGlyphEls.map((el, k) => animateMath(el, prevInners[k], duration)));
+            await Promise.all(rowGlyphEls.map((el, k) => renderStep(el, prevInners[k], duration)));
         } else {
             await sleep(300 * durationMult());
         }
@@ -754,7 +765,7 @@ export function setupApp(
             infoEl.className = 'step-info';
             row.appendChild(infoEl);
             await sleep(150 * durationMult());
-            await animateMath(glyphs, resolventInner, duration);
+            await renderStep(glyphs, resolventInner, duration);
             infoEl.textContent = info;
             infoEl.classList.add('visible');
             centerClause = step.resolvent;


### PR DESCRIPTION
Adds an **`off`** option to the animation selector so stepping the pipeline (forward and Back) and proof rendering snap instantly (via `renderMath`, no tween, no delay). A shared `renderStep()` helper renders instantly when `duration ≤ 0` (also avoids `animateMath`'s divide-by-`duration` at zero). The animation selector is now `slow / normal / fast / off`; music is unaffected.

Supersedes #54, which couldn't merge cleanly because its branch predated the squash-merges of #53/#55. Verified earlier in a headless browser: with animation off, Step ~60 ms / Back ~30 ms, correct state, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)