### PR TITLE
fix(audio): warm-up (no clipped first press) + distinct drum notes for L/R

### DIFF
--- a/src/audio/player.ts
+++ b/src/audio/player.ts
@@ -22,6 +22,34 @@ export function stopMelody(): void {
     activeToken++;
 }
 
+// The audio device takes a moment to actually start producing sound after it
+// is first resumed, so notes scheduled immediately after the very first press
+// get clipped. Warm it up once — resume, prime with an inaudible tick, and
+// wait — so the first press pauses ~1s and every later press plays instantly.
+const WARMUP_MS = 1000;
+let warmup: Promise<void> | null = null;
+
+function ensureWarm(ac: AudioContext | null): Promise<void> {
+    if (warmup !== null) return warmup;
+    warmup = (async () => {
+        if (ac === null) return;
+        try {
+            await ac.resume();
+        } catch { /* ignore */ }
+        try {
+            const gain = ac.createGain();
+            gain.gain.value = 0.0001; // inaudible priming tone
+            const osc = ac.createOscillator();
+            osc.frequency.value = 220;
+            osc.connect(gain).connect(ac.destination);
+            osc.start();
+            osc.stop(ac.currentTime + 0.05);
+        } catch { /* ignore */ }
+        await new Promise<void>((resolve) => setTimeout(resolve, WARMUP_MS));
+    })();
+    return warmup;
+}
+
 export interface PlayOptions {
     direction?: 'forward' | 'reverse';
     noteMs?: number;
@@ -51,20 +79,42 @@ export function playMelody(events: NoteEvent[], opts: PlayOptions = {}): void {
         const event = events[idx];
         opts.onStep?.(idx, event);
         if (event.kind === 'note' && ac !== null) {
-            playTone(ac, event.freq, noteMs);
+            playTone(ac, event.freq, noteMs, event.role);
         }
         step++;
         setTimeout(tick, noteMs);
     };
-    tick();
+    // The first press waits for the one-time device warm-up; later presses
+    // find it already resolved and start immediately.
+    void ensureWarm(ac).then(() => {
+        if (token === activeToken) tick();
+    });
 }
 
-function playTone(ac: AudioContext, freq: number, ms: number): void {
+function playTone(ac: AudioContext, freq: number, ms: number, role: string): void {
     const osc = ac.createOscillator();
     const gain = ac.createGain();
+    const t = ac.currentTime;
+
+    if (role === 'name') {
+        // Constants and predicates are soft percussive "drum" hits: a low sine
+        // with a quick pitch drop and fast decay, so distinct names (e.g. the
+        // L and R banks in wolf-goat-cabbage) read as two different beats and
+        // a run of crossings turns into a rhythm.
+        osc.type = 'sine';
+        osc.frequency.setValueAtTime(freq, t);
+        osc.frequency.exponentialRampToValueAtTime(Math.max(40, freq * 0.6), t + 0.12);
+        gain.gain.setValueAtTime(0.0001, t);
+        gain.gain.exponentialRampToValueAtTime(0.32, t + 0.006);
+        gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.18);
+        osc.connect(gain).connect(ac.destination);
+        osc.start(t);
+        osc.stop(t + 0.2);
+        return;
+    }
+
     osc.type = 'triangle';
     osc.frequency.value = freq;
-    const t = ac.currentTime;
     const dur = ms / 1000;
     // Short attack/decay so notes are plucky, not droning.
     gain.gain.setValueAtTime(0.0001, t);

--- a/src/audio/sonify.test.ts
+++ b/src/audio/sonify.test.ts
@@ -33,14 +33,18 @@ describe('note mapping is consistent and structural', () => {
         }
     });
 
-    it('gives all predicate/function names one shared pitch', () => {
-        const a = noteFor(t('mi', 'MORTAL'));
-        const b = noteFor(t('mi', 'GOD'));
-        expect(a.kind).toBe('note');
-        expect(b.kind).toBe('note');
-        if (a.kind === 'note' && b.kind === 'note') {
-            expect(a.freq).toBe(b.freq); // same pitch; only the glyph differs
+    it('gives distinct names distinct pitches (so L and R are different beats)', () => {
+        const l = noteFor(t('mi', 'L'));
+        const r = noteFor(t('mi', 'R'));
+        expect(l.kind).toBe('note');
+        expect(r.kind).toBe('note');
+        if (l.kind === 'note' && r.kind === 'note') {
+            expect(l.freq).not.toBe(r.freq);
         }
+    });
+
+    it('maps a name deterministically to the same pitch every time', () => {
+        expect(noteFor(t('mi', 'REACH'))).toEqual(noteFor(t('mi', 'REACH')));
     });
 
     it('renders commas as rests', () => {

--- a/src/audio/sonify.ts
+++ b/src/audio/sonify.ts
@@ -52,11 +52,20 @@ const VARIABLE_SEMITONES: Record<string, number> = {
     u: 19, v: 21, w: 23, x: 24, y: 26, z: 28,
 };
 
-// Predicates and functions share one steady lower note — the ear tracks
-// structure, not which name.
-const NAME_SEMITONES = -5; // G3
+// Constants and predicates each get their own low, drum-like pitch, hashed
+// from the name — so distinct names (e.g. the L and R banks in
+// wolf-goat-cabbage) are two different beats, and a run of crossings becomes
+// a rhythm. Low pentatonic (G2 A2 C3 D3 E3), so they stay consonant.
+const NAME_SCALE = [-17, -15, -12, -10, -8];
+function nameSemitones(glyph: string): number {
+    let h = 0;
+    for (let i = 0; i < glyph.length; i++) {
+        h += glyph.charCodeAt(i);
+    }
+    return NAME_SCALE[h % NAME_SCALE.length]!;
+}
 const NUMBER_SEMITONES = -3; // A3
-const PAREN_SEMITONES = -12; // C3, a soft low blip
+const PAREN_SEMITONES = -20; // a soft low blip, below the name drums
 
 function isVariableGlyph(text: string): boolean {
     return /^[u-z]$/.test(text);
@@ -89,7 +98,7 @@ export function noteFor(token: Token): NoteEvent {
         case 'variable':
             return { kind: 'note', role, glyph, freq: freqFromSemitones(VARIABLE_SEMITONES[glyph]!) };
         case 'name':
-            return { kind: 'note', role, glyph, freq: freqFromSemitones(NAME_SEMITONES) };
+            return { kind: 'note', role, glyph, freq: freqFromSemitones(nameSemitones(glyph)) };
         case 'number':
             return { kind: 'note', role, glyph, freq: freqFromSemitones(NUMBER_SEMITONES) };
         case 'paren':


### PR DESCRIPTION
Two audio fixes.

## 1. First-press clipping
The AudioContext has startup latency after its first `resume()`, so notes scheduled immediately were dropped — the first ~second was silent. Now the player **warms up once**: resume + an inaudible priming tick + a 1s wait, gated so only the *first ever* press pauses; every later press plays instantly. Verified in a headless browser: first press ~**1037 ms** then plays, second press **0 ms**.

## 2. L and R sounded the same
Constants and predicates all shared one pitch, so the L/R banks in wolf-goat-cabbage were indistinguishable. Each name now gets **its own low pitch** (hashed to a bass pentatonic) played with a short percussive **drum** envelope. Verified live: `REACH(L,L,L,L) → REACH(R,L,R,L)` plays REACH **98 Hz**, L **110 Hz**, R **130.8 Hz** — distinct beats, so crossings turn into a rhythm.

71 tests + lint + typecheck + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)