### PR TITLE
fix(audio): make L and R clearly distinguishable beats

### DIFF
--- a/src/audio/player.ts
+++ b/src/audio/player.ts
@@ -97,19 +97,18 @@ function playTone(ac: AudioContext, freq: number, ms: number, role: string): voi
     const t = ac.currentTime;
 
     if (role === 'name') {
-        // Constants and predicates are soft percussive "drum" hits: a low sine
-        // with a quick pitch drop and fast decay, so distinct names (e.g. the
-        // L and R banks in wolf-goat-cabbage) read as two different beats and
-        // a run of crossings turns into a rhythm.
-        osc.type = 'sine';
-        osc.frequency.setValueAtTime(freq, t);
-        osc.frequency.exponentialRampToValueAtTime(Math.max(40, freq * 0.6), t + 0.12);
+        // Constants and predicates are tuned percussive hits (a mallet/tom):
+        // a constant pitch — no sweep, so the pitch is clear — with a punchy
+        // attack and a short decay. Distinct names read as different beats, so
+        // e.g. L and R in wolf-goat-cabbage are easy to tell apart.
+        osc.type = 'triangle';
+        osc.frequency.value = freq;
         gain.gain.setValueAtTime(0.0001, t);
-        gain.gain.exponentialRampToValueAtTime(0.32, t + 0.006);
-        gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.18);
+        gain.gain.exponentialRampToValueAtTime(0.34, t + 0.005);
+        gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.24);
         osc.connect(gain).connect(ac.destination);
         osc.start(t);
-        osc.stop(t + 0.2);
+        osc.stop(t + 0.26);
         return;
     }
 

--- a/src/audio/sonify.ts
+++ b/src/audio/sonify.ts
@@ -52,11 +52,12 @@ const VARIABLE_SEMITONES: Record<string, number> = {
     u: 19, v: 21, w: 23, x: 24, y: 26, z: 28,
 };
 
-// Constants and predicates each get their own low, drum-like pitch, hashed
-// from the name — so distinct names (e.g. the L and R banks in
-// wolf-goat-cabbage) are two different beats, and a run of crossings becomes
-// a rhythm. Low pentatonic (G2 A2 C3 D3 E3), so they stay consonant.
-const NAME_SCALE = [-17, -15, -12, -10, -8];
+// Constants and predicates each get their own pitch, hashed from the name —
+// so distinct names (e.g. the L and R banks in wolf-goat-cabbage) are clearly
+// different beats and a run of crossings becomes a rhythm. A two-octave
+// pentatonic (C3–A4) keeps them consonant, in a register small speakers
+// actually reproduce, and far enough apart to tell by ear.
+const NAME_SCALE = [-12, -10, -8, -5, -3, 0, 2, 4, 7, 9];
 function nameSemitones(glyph: string): number {
     let h = 0;
     for (let i = 0; i < glyph.length; i++) {


### PR DESCRIPTION
## What & why

L and R still sounded the same. Two causes:
1. They were only a **minor third** apart.
2. They were pitched **very low** (82–131 Hz) with a **pitch-drop** envelope — laptop/phone speakers barely reproduce that range, and the downward sweep smears the pitch into a generic thump.

Fix:
- Move names to a **two-octave pentatonic in the mid register** (C3–A4). L lands on **D4 (293.7 Hz)**, R on **E3 (164.8 Hz)** — **~10 semitones apart** and in a range every speaker handles.
- Play names as a **constant-pitch tuned percussive hit** (mallet/tom), no sweep, so the pitch is unambiguous.

Verified in a headless browser: `REACH(L,L,L,L) → REACH(R,L,R,L)` plays R 164.8, REACH 261.6, L 293.7 Hz — clearly distinct beats. 71 tests + lint + typecheck + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)